### PR TITLE
Adds session form, allowing signin and signup

### DIFF
--- a/frontend/components/app.jsx
+++ b/frontend/components/app.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import HomeContainer from './home/home_container';
 import LoginFormContainer from './session_form/login_form_container';
+import SignUpFormContainer from './session_form/signup_form_container';
 import {
   Route,
   Redirect,
@@ -14,7 +15,7 @@ const App = () => (
     <HomeContainer />
     <h1>StayOnTrack is changing how teams build software-- one story at a time</h1>
     <Route path="/signin" component={LoginFormContainer} />
-    <Route path="/signup" component={LoginFormContainer} />
+    <Route path="/signup" component={SignUpFormContainer} />
   </>
 );
 

--- a/frontend/components/app.jsx
+++ b/frontend/components/app.jsx
@@ -1,10 +1,20 @@
 import React from "react";
 import HomeContainer from './home/home_container';
+import LoginFormContainer from './session_form/login_form_container';
+import {
+  Route,
+  Redirect,
+  Switch,
+  Link,
+  HashRouter
+} from 'react-router-dom';
 
 const App = () => (
   <>
     <HomeContainer />
     <h1>StayOnTrack is changing how teams build software-- one story at a time</h1>
+    <Route path="/signin" component={LoginFormContainer} />
+    <Route path="/signup" component={LoginFormContainer} />
   </>
 );
 

--- a/frontend/components/session_form/login_form_container.js
+++ b/frontend/components/session_form/login_form_container.js
@@ -1,0 +1,15 @@
+import { connect } from "react-redux";
+import React from "react";
+import { login } from "../../actions/session_actions";
+import SessionForm from './session_form';
+
+const mapStateToProps = ({ errors }) => ({
+  errors: errors.session,
+  formTyoe: 'login'
+});
+
+const mapDispatchToProps = dispatch => ({
+  processForm: user => dispatch(login(user))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(SessionForm)

--- a/frontend/components/session_form/login_form_container.js
+++ b/frontend/components/session_form/login_form_container.js
@@ -6,7 +6,7 @@ import SessionForm from './session_form';
 
 const mapStateToProps = ({ errors }) => ({
   errors: errors.session,
-  formTyoe: 'Sign In',
+  formType: 'Sign In',
   navLink: <Link to="/signup">SIGN UP</Link>
 });
 

--- a/frontend/components/session_form/login_form_container.js
+++ b/frontend/components/session_form/login_form_container.js
@@ -7,7 +7,8 @@ import SessionForm from './session_form';
 const mapStateToProps = ({ errors }) => ({
   errors: errors.session,
   formType: 'Sign In',
-  navLink: <Link to="/signup">SIGN UP</Link>
+  navLink: <div>DON'T HAVE AN ACCOUNT? <Link to="/signup">SIGN UP</Link></div>,
+  formDescription: 'Sign in to continue to Pivotal Tracker.'
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/components/session_form/login_form_container.js
+++ b/frontend/components/session_form/login_form_container.js
@@ -1,15 +1,17 @@
-import { connect } from "react-redux";
 import React from "react";
+import { Link } from "react-router-dom";
+import { connect } from "react-redux";
 import { login } from "../../actions/session_actions";
 import SessionForm from './session_form';
 
 const mapStateToProps = ({ errors }) => ({
   errors: errors.session,
-  formTyoe: 'login'
+  formTyoe: 'Sign In',
+  navLink: <Link to="/signup">SIGN UP</Link>
 });
 
 const mapDispatchToProps = dispatch => ({
   processForm: user => dispatch(login(user))
 });
 
-export default connect(mapStateToProps, mapDispatchToProps)(SessionForm)
+export default connect(mapStateToProps, mapDispatchToProps)(SessionForm);

--- a/frontend/components/session_form/session_form.jsx
+++ b/frontend/components/session_form/session_form.jsx
@@ -38,19 +38,18 @@ class SessionForm extends React.Component {
   }
 
   render () {
-    const { navLink, formType } = this.props;
-    
+    const { navLink, formType, formDescription } = this.props;
     return (
       <>
       <header>
         <Link to="/">StayOnTrack</Link>
-        <div>{ navLink }</div>
+          {navLink}
       </header>
       <section className="login-form">
-        <h1>{ formType }</h1>
-        <h2>Sign in to continue to StayOnTrack</h2>
+        <h2>{ formType }</h2> 
+        <h3>{formDescription}</h3>
         <form onSubmit={this.handleSubmit}>
-          <label>Sign in as
+          <label>Email
             <input type="text" 
               value={this.state.email}
               onChange={this.update("email")}

--- a/frontend/components/session_form/session_form.jsx
+++ b/frontend/components/session_form/session_form.jsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Link } from "react-router-dom";
+
+class SessionForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      email: '',
+      password: ''
+    };
+
+    this.handleSubmit = this.handleSubmit.bind(this);
+
+  }
+
+  update(field) {
+    return e => this.setState({
+      [field]: e.currentTarget.value
+    });
+  }
+
+  handleSubmit(e) {
+    e.preventDefault();
+    const user = Object.assign({}, this.state);
+    this.props.processForm(user);
+  }
+
+  renderErrors() {
+    return(
+      <ul>
+        {this.props.errors.map((error, i) => (
+          <li key={`error-${i}`}>
+            {error}
+          </li>
+        ))}
+      </ul>
+    )
+  }
+
+  render () {
+    return (
+      <>
+      <header>
+        <Link to="/">StayOnTrack</Link>
+        <div>{this.props.navLink}</div>
+      </header>
+      <section className="login-form">
+        <h1>{this.props.formType}</h1>
+        <h2>Sign in to continue to StayOnTrack</h2>
+        <form onSubmit={this.handleSubmit}>
+          <label>Sign in as
+            <input type="text" 
+              value={this.state.email}
+              onChange={this.update("email")}
+            />
+          </label>
+          <label>Password
+            <input type="password" 
+              value={this.state.password} 
+              onChange={this.update("password")}
+            />
+          </label>
+          <input type="submit" value={this.props.formType} />
+        </form>
+      </section>
+      </>
+    );
+  }
+}
+
+export default SessionForm;

--- a/frontend/components/session_form/session_form.jsx
+++ b/frontend/components/session_form/session_form.jsx
@@ -38,14 +38,16 @@ class SessionForm extends React.Component {
   }
 
   render () {
+    const { navLink, formType } = this.props;
+    
     return (
       <>
       <header>
         <Link to="/">StayOnTrack</Link>
-        <div>{this.props.navLink}</div>
+        <div>{ navLink }</div>
       </header>
       <section className="login-form">
-        <h1>{this.props.formType}</h1>
+        <h1>{ formType }</h1>
         <h2>Sign in to continue to StayOnTrack</h2>
         <form onSubmit={this.handleSubmit}>
           <label>Sign in as
@@ -60,7 +62,7 @@ class SessionForm extends React.Component {
               onChange={this.update("password")}
             />
           </label>
-          <input type="submit" value={this.props.formType} />
+          <input type="submit" value={ formType } />
         </form>
       </section>
       </>

--- a/frontend/components/session_form/signup_form_container.js
+++ b/frontend/components/session_form/signup_form_container.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { connect } from "react-redux";
+import { signup } from "../../actions/session_actions";
+import SessionForm from './signup';
+
+const mapStateToProps = ({ errors }) => ({
+  errors: errors.session,
+  formType: 'Sign Up',
+  navLink: <Link to="/login">Sign In</Link>
+});
+
+const mapDispatchToProps = dispatch => ({
+  signup: user => dispatch(signup(user))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(SessionForm);

--- a/frontend/components/session_form/signup_form_container.js
+++ b/frontend/components/session_form/signup_form_container.js
@@ -2,16 +2,16 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { connect } from "react-redux";
 import { signup } from "../../actions/session_actions";
-import SessionForm from './signup';
+import SessionForm from "./session_form";
 
 const mapStateToProps = ({ errors }) => ({
   errors: errors.session,
   formType: 'Sign Up',
-  navLink: <Link to="/login">Sign In</Link>
+  navLink: <div>Already have an account? <Link to="/signin">Sign In</Link></div>
 });
 
 const mapDispatchToProps = dispatch => ({
-  signup: user => dispatch(signup(user))
+  processForm: user => dispatch(signup(user))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(SessionForm);


### PR DESCRIPTION
Both Sign Up and Sign In take in an email and a password as attributes. There are a few things that need changes going forward.

### To do:
+ Update schema, user model,  users controller, views to ensure that only email and password are required for user creation

### If time permits:
+ Add ability for user to sign in with either username or log in
+ Set name and username equal to the first part of the email on user creation