### PR TITLE
Fix user schema

### DIFF
--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -15,7 +15,7 @@ class Api::SessionsController < ApplicationController
 
     if @user
       logout!
-      @user = { id:"", username:"", email:"", firstname:"", lastname:"" }
+      @user = { id:"", email:"" }
       render "api/users/show"
     else
       render json: ["No one is signed in"], status: 404

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -11,6 +11,6 @@ class Api::UsersController < ApplicationController
 
   private
   def user_params
-    params.require(:user).permit(:email, :password, :username, :firstname, :lastname)
+    params.require(:user).permit(:email, :password)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,18 +3,15 @@
 # Table name: users
 #
 #  id              :bigint           not null, primary key
-#  username        :string           not null
 #  email           :string           not null
-#  firstname       :string           not null
-#  lastname        :string           not null
 #  password_digest :string           not null
 #  session_token   :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #
 class User < ApplicationRecord
-  validates :username, :email, :session_token, presence: true, uniqueness: true
-  validates :firstname, :lastname, :password_digest, presence: true
+  validates :email, :session_token, presence: true, uniqueness: true
+  validates :password_digest, presence: true
   validates :password, length: {minimum: 6}, allow_nil: true
   attr_reader :password
 

--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! user, :id, :username, :email, :firstname, :lastname
+json.extract! user, :id, :email

--- a/db/migrate/20200408174200_update_users.rb
+++ b/db/migrate/20200408174200_update_users.rb
@@ -1,0 +1,7 @@
+class UpdateUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :firstname
+    remove_column :users, :lastname
+    remove_column :users, :username
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,23 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_07_093924) do
+ActiveRecord::Schema.define(version: 2020_04_08_174200) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.string "username", null: false
     t.string "email", null: false
-    t.string "firstname", null: false
-    t.string "lastname", null: false
     t.string "password_digest", null: false
     t.string "session_token", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["session_token"], name: "index_users_on_session_token", unique: true
-    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
 end

--- a/frontend/components/home/home.jsx
+++ b/frontend/components/home/home.jsx
@@ -7,8 +7,8 @@ const Home = ({ currentUser }) => (
       <a className="header-link">Product</a>
       <a className="header-link">Community</a>
       <a href="https://www.pivotaltracker.com/blog">Blog</a>
-      <Link to="/login">Login</Link>
-      <Link to="/signup">Signup</Link>
+      <Link to="/signin">Sign In</Link>
+      <Link to="/signup">Sign Up</Link>
     </nav>
 );
 


### PR DESCRIPTION
Users do not actually need firstname, lastname, or username to create a new account. PR updates the schema to remove these conditions. 

### If time permits, will do the following:
+ Add feature that automatically creates username  for user based on first half of email string
+ Add feature that automatically creates name for user equal to the username
+ Add feature that automatically creates initials  for user equivalent to first two letters of username