### PR TITLE
Adds utilities for protected and auth routes, cleans up a few naming issues

### DIFF
--- a/app/assets/stylesheets/base/layout.scss
+++ b/app/assets/stylesheets/base/layout.scss
@@ -1,48 +1,3 @@
-@media only screen and (min-width: 62rem) {
-  .banner-msg {
-    box-sizing: border-box;
-    flex: 0 0 auto;
-    padding-left: 16px;
-    padding-right: 16px;
-  }
-}
-
-@media (min-width: 592px) {
-  .page-container {
-    padding: 0 16px;
-    width: 560px;
-  }
-}
-
-@media (min-width: 992px) {
-  h1 {
-    font-size: 32px;
-    line-height: 40px;
-    text-align: center;
-  }
-  h2 {
-    font-size: 24px;
-    line-height: 32px;
-    margin: 0 auto 48px;
-    margin-top: 0px;
-    margin-right: auto;
-    margin-bottom: 48px;
-    margin-left: auto;
-    text-align: center;
-  }
-  .page-container {
-    width: 960px;
-    margin: 0 auto;
-  }
-  .hero {
-    height: 538px;
-    text-align: center;
-  }
-  .section-md {
-    margin-bottom: 40px;
-  }
-}
-
 html {
 	position: relative;
 	height: 100%;
@@ -140,3 +95,49 @@ p {
 /*
 	Inputs
 */
+
+/* Media Queries */
+@media only screen and (min-width: 62rem) {
+  .banner-msg {
+    box-sizing: border-box;
+    flex: 0 0 auto;
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+}
+
+@media (min-width: 592px) {
+  .page-container {
+    padding: 0 16px;
+    width: 560px;
+  }
+}
+
+@media (min-width: 992px) {
+  h1 {
+    font-size: 32px;
+    line-height: 40px;
+    text-align: center;
+  }
+  h2 {
+    font-size: 24px;
+    line-height: 32px;
+    margin: 0 auto 48px;
+    margin-top: 0px;
+    margin-right: auto;
+    margin-bottom: 48px;
+    margin-left: auto;
+    text-align: center;
+  }
+  .page-container {
+    width: 960px;
+    margin: 0 auto;
+  }
+  .hero {
+    height: 538px;
+    text-align: center;
+  }
+  .section-md {
+    margin-bottom: 40px;
+  }
+}

--- a/app/assets/stylesheets/home_components/_main_content.scss
+++ b/app/assets/stylesheets/home_components/_main_content.scss
@@ -1,28 +1,4 @@
 // Work in progress elements will neeed to be adjusted later
-@media (max-width: 320px) {
-  .work-in-progress {
-    margin-top: 16px;
-  }
-}
-
-@media (min-width: 592px) {
-  .work-in-progress {
-    margin-top: 16px;
-  }
-}
-
-@media (min-width: 992px) {
-  .work-in-progress {
-    margin-left: 64px;
-  }
-
-  h3.banner-msg {
-    font-size: 24px;
-    line-height: 32px;
-    margin: 0 auto 48px;
-    text-align: center;
-  }
-}
 .work-in-progress {
   color: white;
   width: 370px;
@@ -95,4 +71,30 @@ h3.banner-msg {
   margin: 0 auto 48px;
   text-align: center;
   font-weight: 300;
+}
+
+/* Media Queries */
+@media (max-width: 320px) {
+  .work-in-progress {
+    margin-top: 16px;
+  }
+}
+
+@media (min-width: 592px) {
+  .work-in-progress {
+    margin-top: 16px;
+  }
+}
+
+@media (min-width: 992px) {
+  .work-in-progress {
+    margin-left: 64px;
+  }
+
+  h3.banner-msg {
+    font-size: 24px;
+    line-height: 32px;
+    margin: 0 auto 48px;
+    text-align: center;
+  }
 }

--- a/app/assets/stylesheets/home_components/_main_nav.scss
+++ b/app/assets/stylesheets/home_components/_main_nav.scss
@@ -1,9 +1,3 @@
-@media (min-width: 992px) {
-  .header__link {
-    margin-left: 24px;
-  }
-}
-
 .main-nav {
   background-color: white;
   border-bottom: 1px solid #c3d4e5;
@@ -28,4 +22,10 @@
 
 .header-link:last-child {
   margin-left: 8px; 
+}
+
+@media (min-width: 992px) {
+  .header_link {
+    margin-left: 24px;
+  }
 }

--- a/frontend/components/app.jsx
+++ b/frontend/components/app.jsx
@@ -1,7 +1,5 @@
 import React from "react";
-import HomeContainer from './home/home_container';
-import LoginFormContainer from './session_form/login_form_container';
-import SignUpFormContainer from './session_form/signup_form_container';
+import { Provider } from 'react-redux';
 import {
   Route,
   Redirect,
@@ -10,12 +8,20 @@ import {
   HashRouter
 } from 'react-router-dom';
 
+import HomeContainer from './home/home_container';
+import LoginFormContainer from './session_form/login_form_container';
+import SignUpFormContainer from './session_form/signup_form_container';
+import DashboardContainer from './dashboard/dashboard_container';
+import { AuthRoute, ProtectedRoute } from '../util/route_util';
+
+
 const App = () => (
-  <>
-    <HomeContainer />
-    <Route path="/signin" component={LoginFormContainer} />
-    <Route path="/signup" component={SignUpFormContainer} />
-  </>
+  <Switch>
+    <AuthRoute exact path="/" component={HomeContainer} />
+    <AuthRoute path="/login" component={LoginFormContainer} />
+    <AuthRoute path="/signup" component={SignUpFormContainer} />
+    <ProtectedRoute path="/dashboard" component={DashboardContainer} />
+  </Switch>
 );
 
 export default App;

--- a/frontend/components/dashboard/dashboard.jsx
+++ b/frontend/components/dashboard/dashboard.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+class Dashboard extends React.Component {
+  constructor (props) {
+    super(props);
+  }
+
+  render() {
+    const { logout } = this.props;
+
+    return (
+      <>
+        <h1 className="under-construction">Hello World!</h1>
+        < button className = "btn btn-blue" onClick = { logout } > Log Out </button>
+      </>
+    );
+  }
+}
+
+export default Dashboard;

--- a/frontend/components/dashboard/dashboard_container.js
+++ b/frontend/components/dashboard/dashboard_container.js
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux';
+import { logout } from '../../actions/session_actions';
+import Dashboard from './dashboard';
+
+
+const mapStateToProps = ({ session, entities: { users } }) => {
+  return {
+    currentUser: users[session.id]
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  logout: () => dispatch(logout())
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(Dashboard);

--- a/frontend/components/home/home.jsx
+++ b/frontend/components/home/home.jsx
@@ -13,8 +13,8 @@ const Home = ({ currentUser }) => (
             <a className="header-link">Product</a>
             <a className="header-link">Community</a>
             <a href="https://www.pivotaltracker.com/blog" className="header-link">Blog</a>
-            <Link id="sign-in-link" className="header-link btn btn-orange" to="/signin">Sign In</Link>
-            <Link id="sign-up-link" className="header-link btn btn-blue" to="/signup">Sign Up</Link>
+            <Link className="header-link btn btn-orange" to="/login">Log In</Link>
+            <Link className="header-link btn btn-blue" to="/signup">Sign Up</Link>
           </div>
         </div>
       </div>

--- a/frontend/components/home/home.jsx
+++ b/frontend/components/home/home.jsx
@@ -23,7 +23,8 @@ const Home = ({ currentUser }) => (
       <section className="hero">
         <div className="text-box">
           <h1 className="hero-heading">
-            StayOnTrack is changing how teams build software-- one story at a time
+            StayOnTrack is changing how teams build software&mdash;
+            <br/> one story at a time
           </h1>
           <div className="work-in-progress">
             Work in progress ...

--- a/frontend/components/session_form/login_form_container.js
+++ b/frontend/components/session_form/login_form_container.js
@@ -6,9 +6,9 @@ import SessionForm from './session_form';
 
 const mapStateToProps = ({ errors }) => ({
   errors: errors.session,
-  formType: 'Sign In',
+  formType: 'Log In',
   navLink: <div>DON'T HAVE AN ACCOUNT? <Link to="/signup">SIGN UP</Link></div>,
-  formDescription: 'Sign in to continue to Pivotal Tracker.'
+  formDescription: 'Log In to continue to Pivotal Tracker.'
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/components/session_form/signup_form_container.js
+++ b/frontend/components/session_form/signup_form_container.js
@@ -7,7 +7,7 @@ import SessionForm from "./session_form";
 const mapStateToProps = ({ errors }) => ({
   errors: errors.session,
   formType: 'Sign Up',
-  navLink: <div>Already have an account? <Link to="/signin">Sign In</Link></div>
+  navLink: <div>Already have an account? <Link to="/login">Log In</Link></div>
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/frontend/util/route_util.jsx
+++ b/frontend/util/route_util.jsx
@@ -1,0 +1,31 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { Redirect, Route, withRouter } from "react-router-dom";
+
+
+const Auth = ({ component: Component, path, loggedIn, exact }) => (
+  <Route path={path} exact={exact} render={(props) => (
+    !loggedIn ? (
+      <Component {...props} /> 
+    ) : (
+      <Redirect to="/dashboard" />
+    )
+  )} />
+)
+
+const Protected = ({ component: Component, path, loggedIn, exact }) => (
+  <Route path={path} exact={exact} render={(props) => (
+    loggedIn ? (
+      <Component {...props} />
+    ) : (
+        <Redirect to="/login" />
+      )
+  )} />
+)
+
+const mapStateToProps = state => {
+  return { loggedIn: Boolean(state.session.id) };
+};
+
+export const AuthRoute = withRouter(connect(mapStateToProps)(Auth));
+export const ProtectedRoute = withRouter(connect(mapStateToProps)(Protected));


### PR DESCRIPTION
The home page (used for advertising and routing) is now only viewable to users who are not logged in. A logged in user will treat the dashboard as their main page.

Initially, in order to match the website, I included Sign In as the phrase for logging in. This was causing confusion while coding. I changed all mentions of Sign In to Log In. I will consider switching everything to Sign In at a later time.