### PR TITLE
Adds feature to automatically create username, name, initials on user creation

### DIFF
--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -15,7 +15,7 @@ class Api::SessionsController < ApplicationController
 
     if @user
       logout!
-      @user = { id:"", email:"" }
+      @user = { id:"", email:"", username:"", name:"", initials:"" }
       render "api/users/show"
     else
       render json: ["No one is signed in"], status: 404

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,6 +1,6 @@
 class Api::UsersController < ApplicationController
   def create
-    @user = User.new(user_params)
+    @user = User.new(params_with_username_initials)
     if @user.save
       login!(@user)
       render "/api/users/show"
@@ -10,7 +10,19 @@ class Api::UsersController < ApplicationController
   end
 
   private
-  def user_params
-    params.require(:user).permit(:email, :password)
+  def params_with_username_initials
+    email = params[:user][:email]
+    password = params[:user][:password]
+    username = email.split("@").first
+    name = username.clone
+    initials = username.first(2).upcase
+
+    until !User.find_by(username: username)
+      count = 1
+      username = username + count.to_s
+      count += 1
+    end
+
+    params_with_username_initials = { email: email, password: password, username: username, name: name, initials: initials }
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,7 +23,7 @@ class ApplicationController < ActionController::Base
     @current_user = nil
   end
 
-    def ensure_logged_in
+  def ensure_logged_in
     unless current_user
       render json: { base: ['invalid credentials'] }, status: 401
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,10 +8,13 @@
 #  session_token   :string           not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  username        :string           not null
+#  name            :string           not null
+#  initials        :string           not null
 #
 class User < ApplicationRecord
-  validates :email, :session_token, presence: true, uniqueness: true
-  validates :password_digest, presence: true
+  validates :email, :session_token, :username, presence: true, uniqueness: true
+  validates :password_digest, :name, :initials, presence: true
   validates :password, length: {minimum: 6}, allow_nil: true
   attr_reader :password
 

--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! user, :id, :email
+json.extract! user, :id, :email, :username, :name, :initials

--- a/db/migrate/20200413112652_add_username_initials_to_users.rb
+++ b/db/migrate/20200413112652_add_username_initials_to_users.rb
@@ -1,0 +1,9 @@
+class AddUsernameInitialsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :username, :string, null: false
+    add_column :users, :name, :string, null: false
+    add_column :users, :initials, :string, null: false
+
+    add_index :users, :username, { unique: true }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_08_174200) do
+ActiveRecord::Schema.define(version: 2020_04_13_112652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,8 +21,12 @@ ActiveRecord::Schema.define(version: 2020_04_08_174200) do
     t.string "session_token", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "username", null: false
+    t.string "name", null: false
+    t.string "initials", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["session_token"], name: "index_users_on_session_token", unique: true
+    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,4 +6,4 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
-demo_user = User.create({email: "demo_user@mailinator.com", password: "password"})
+demo_user = User.create({email: "demo_user@mailinator.com", password: "password", username: "demo_user", name: "demo_user", initials: "DE"})


### PR DESCRIPTION
### Background 
In order to create a new account a user must only pass in a unique email with a valid password. However, throughout the app, the user is generally referenced by either their username, name or initials. These values are required and are also assigned automatically by the app on user creation.

### Technical Notes
A `username` must be unique and is generated from the first part of  an email address before the `@` symbol. This value is not inherently unique. In order to get around this problem, the app iteratively appends a number to the end of the `username` until it finds one that is unique.

### Future Improvements
Username, name, and initials all are values that a user should be allowed to edit independently of the email login credentials. These are features to be added in future MVPs.