### PR TITLE
Add member on create

### DIFF
--- a/app/controllers/api/project_memberships_controller.rb
+++ b/app/controllers/api/project_memberships_controller.rb
@@ -1,9 +1,9 @@
 class Api::ProjectMembershipsController < ApplicationController
   def create
     @project_membership = ProjectMembership.new(project_membership_params)
-
     if @project_membership.save
-      render "/api/projects/show"
+      @project = Project.find(@project_membership.project_id)
+      render json: @project
     else
       render json: @user.errors.full_messages, status: 422
     end

--- a/app/models/project_membership.rb
+++ b/app/models/project_membership.rb
@@ -9,7 +9,8 @@
 #  updated_at       :datetime         not null
 
 class ProjectMembership < ApplicationRecord
-  validates :member_id, :uniqueness {scope: :project_id }
+  validates :member_id, uniqueness: {scope: :project_id }
+
   belongs_to :member,
     foreign_key: :member_id,
     class_name: :User

--- a/app/models/project_membership.rb
+++ b/app/models/project_membership.rb
@@ -9,6 +9,7 @@
 #  updated_at       :datetime         not null
 
 class ProjectMembership < ApplicationRecord
+  validates :member_id, :uniqueness {scope: :project_id }
   belongs_to :member,
     foreign_key: :member_id,
     class_name: :User

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: { format: :json } do
     resources :users, only: [:create]
     resources :projects, only: [:index, :create, :show]
+    resources :project_memberships, only: [:create]
     resource :session, only: [:create, :destroy, :show]
   end
   root to: "static_pages#root"

--- a/db/migrate/20200417143524_add_index_on_project_memberships.rb
+++ b/db/migrate/20200417143524_add_index_on_project_memberships.rb
@@ -1,0 +1,5 @@
+class AddIndexOnProjectMemberships < ActiveRecord::Migration[5.2]
+  def change
+    add_index :project_memberships, [:member_id, :project_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_14_211036) do
+ActiveRecord::Schema.define(version: 2020_04_17_143524) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2020_04_14_211036) do
     t.integer "project_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["member_id", "project_id"], name: "index_project_memberships_on_member_id_and_project_id"
   end
 
   create_table "projects", force: :cascade do |t|

--- a/frontend/actions/project_actions.js
+++ b/frontend/actions/project_actions.js
@@ -27,8 +27,18 @@ export const fetchProject = id => dispatch => (
 );
 
 export const createProject = project => dispatch => (
-  ProjectApiUtil.createProject(project).then(project => {
-    dispatch(receiveProject(project));
+  ProjectApiUtil.createProject(project)
+  // ProjectApiUtil.createProjectMembership({ project_id: project.id, member_id: project.project_owner_id });
+    .then(project => {
+      dispatch(receiveProject(project));
     return project;
   })
+);
+
+export const createProjectMembership = projectMembership => dispatch => (
+  ProjectApiUtil.createProjectMembership(projectMembership)
+    .then(project => {
+      dispatch(receiveProject(project));
+      return project;
+    })
 );

--- a/frontend/components/project/project_detail.jsx
+++ b/frontend/components/project/project_detail.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ProtectedRoute } from '../../util/route_util';
 import TopNavigation from "../navigation/top_navigation";
 
 class ProjectDetail extends React.Component {
@@ -14,7 +13,7 @@ class ProjectDetail extends React.Component {
   
 
   render() {
-    const { currentUser, project, logout, projectsDropdownLabel } = this.props;
+    const { currentUser, logout, projectsDropdownLabel } = this.props;
 
     return (
       <>
@@ -41,9 +40,9 @@ class ProjectDetail extends React.Component {
               <header>
                 <h1>Current Iteration/Backlog</h1>
                 <div className="project-detail-actions">
-                  <span><i class="fas fa-plus"></i> Add Story</span>
-                  <span><i class="fas fa-ellipsis-v"></i></span>
-                  <span><i class="fas fa-times"></i></span>
+                  <span><i className="fas fa-plus"></i> Add Story</span>
+                  <span><i className="fas fa-ellipsis-v"></i></span>
+                  <span><i className="fas fa-times"></i></span>
                 </div>
               </header>
               <section className="stories-stack">

--- a/frontend/components/project_form/project_form.jsx
+++ b/frontend/components/project_form/project_form.jsx
@@ -22,8 +22,9 @@ class ProjectForm extends React.Component {
     e.preventDefault();
     const project = Object.assign({}, this.state);
     this.props.closeModal();
-    this.props.createProject(project).then(newProject => {
-      this.props.history.push(`/projects/${newProject.id}`);
+    this.props.createProject(project)
+      .then(newProject => {
+        this.props.history.push(`/projects/${newProject.id}`);
     });
   }
 

--- a/frontend/components/project_form/project_form_container.js
+++ b/frontend/components/project_form/project_form_container.js
@@ -10,6 +10,7 @@ const mapStateToProps = ({ session, entities: { users } }) => ({
 
 const mapDispatchToProps = dispatch => ({
   createProject: project => dispatch(createProject(project)),
+  createProjectMembership: project_membership => dispatch(createProjectMembership(project_membership)),
   closeModal: () => dispatch(closeModal())
 });
 

--- a/frontend/stay_on_track.jsx
+++ b/frontend/stay_on_track.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import configureStore from "./store/store";
 import Root from "./components/root";
+import * as ProjectApiUtil from "./util/projects_api_util";
 import * as SessionActions from "./actions/session_actions";
 import * as ProjectActions from "./actions/project_actions";
 
@@ -29,6 +30,8 @@ document.addEventListener("DOMContentLoaded", () => {
   window.login = SessionActions.login;
   window.logout = SessionActions.logout;
   window.createProject = ProjectActions.createProject;
+  window.ApiMembership = ProjectApiUtil.createProjectMembership;
+  window.createProjectMembership = ProjectActions.createProjectMembership;
   window.fetchProject = ProjectActions.fetchProject;
   window.fetchProjects = ProjectActions.fetchProjects;
   // TESTING

--- a/frontend/util/projects_api_util.js
+++ b/frontend/util/projects_api_util.js
@@ -1,10 +1,18 @@
-export const fetchProjects = data => (
-  $.ajax({
-    method: 'GET',
-    url: 'api/projects',
-    data
-  })
-);
+// export const fetchProjects = data => (
+//   $.ajax({
+//     method: 'GET',
+//     url: 'api/projects',
+//     data
+//   })
+// );
+
+export const fetchProjects = data => {
+  return $.ajax({
+      method: 'GET',
+      url: 'api/projects',
+      data
+    });
+};
 
 export const fetchProject = (id) => (
   $.ajax({
@@ -21,8 +29,10 @@ export const createProject = (project) => (
   })
 );
 
-export const createProjectMembership = (projectMembership) => (
+export const createProjectMembership = (project_membership) => (
   $.ajax({
-    url: "/"
+    url: "/api/project_memberships",
+    method: "POST",
+    data: { project_membership }
   })
-)
+);

--- a/frontend/util/projects_api_util.js
+++ b/frontend/util/projects_api_util.js
@@ -20,3 +20,9 @@ export const createProject = (project) => (
     data: { project }
   })
 );
+
+export const createProjectMembership = (projectMembership) => (
+  $.ajax({
+    url: "/"
+  })
+)


### PR DESCRIPTION
### Summary
A user is now able to dispatch a thunk action creator in order to add a member to a project.

### Up Next
Initial goal was to allow a project membership to be added on creation. This proved more difficult than expected. This goal is still in progress.