### PR TITLE
Renames story type column for stories table

### DIFF
--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -19,6 +19,6 @@ class Api::StoriesController < ApplicationController
 
   private
   def story_params
-    params.require(:story).permit(:name, :type, :story_owner_id, :project_id, :story_state)
+    params.require(:story).permit(:name, :story_type, :story_owner_id, :project_id, :story_state)
   end
 end

--- a/app/models/story.rb
+++ b/app/models/story.rb
@@ -4,7 +4,7 @@
 #
 #  id                :bigint           not null, primary key
 #  name              :string           not null
-#  type              :integer          not null
+#  story_type        :integer          not null
 #  story_owner_id    :integer          not null
 #  project_id        :integer          not null
 #  story_state       :string           not null
@@ -14,7 +14,7 @@
 #  updated_at        :datetime         not null
 #
 class Story < ApplicationRecord
-  validates :name, :type, :story_owner_id, :story_state, presence: true
+  validates :name, :story_type, :story_owner_id, :story_state, presence: true
 
   belongs_to :project,
     foreign_key: :project_id,
@@ -24,7 +24,7 @@ class Story < ApplicationRecord
     foreign_key: :story_owner_id,
     class_name: :User
 
-  belongs_to :story_assignee,
-    foreign_key: :story_assignee_id,
-    class_name: :User
+  # belongs_to :story_assignee,
+  #  foreign_key: :story_assignee_id,
+  #  class_name: :User
 end

--- a/app/views/api/stories/_story.json.jbuilder
+++ b/app/views/api/stories/_story.json.jbuilder
@@ -1,1 +1,1 @@
-json.extract! story, :id, :name, :type, :story_owner_id, :story_state, :story_assignee_id, :description
+json.extract! story, :id, :name, :story_type, :story_owner_id, :story_state, :story_assignee_id, :description

--- a/db/migrate/20200529153902_fix_stories_column_name.rb
+++ b/db/migrate/20200529153902_fix_stories_column_name.rb
@@ -1,0 +1,5 @@
+class FixStoriesColumnName < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :stories, :type, :story_type
+  end
+end

--- a/db/migrate/20200529155628_change_stories_column_data_type.rb
+++ b/db/migrate/20200529155628_change_stories_column_data_type.rb
@@ -1,0 +1,5 @@
+class ChangeStoriesColumnDataType < ActiveRecord::Migration[5.2]
+  def change
+    change_column :stories, :story_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_29_153902) do
+ActiveRecord::Schema.define(version: 2020_05_29_155628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2020_05_29_153902) do
 
   create_table "stories", force: :cascade do |t|
     t.string "name", null: false
-    t.integer "story_type", null: false
+    t.string "story_type", null: false
     t.integer "story_owner_id", null: false
     t.integer "project_id", null: false
     t.string "story_state", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_27_224706) do
+ActiveRecord::Schema.define(version: 2020_05_29_153902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 2020_05_27_224706) do
 
   create_table "stories", force: :cascade do |t|
     t.string "name", null: false
-    t.integer "type", null: false
+    t.integer "story_type", null: false
     t.integer "story_owner_id", null: false
     t.integer "project_id", null: false
     t.string "story_state", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,3 +9,6 @@
 demo_user_1 = User.create({ email: "demo_user@mailinator.com", password: "password", username: "demo_user", name: "demo_user", initials: "DE" })
 demo_project_1 = Project.create({ title: "My First Project", project_owner_id: 1 })
 demo_project_membership_1 = ProjectMembership.create({ member_id: 1, project_id: 1 })
+
+# demo_project_1_story_1  = Story.create({name: "My First Story", story_type: "feature", story_owner_id: 1, project_id: 1, story_state: "unassigned"}):name, :type, :story_owner_id, :project_id, :story_state
+# Story.new({name: "My First Story", story_type: "feature", story_owner_id: 1, project_id: 1, story_state: "unassigned"})


### PR DESCRIPTION
### Summary
`type` is a reserved term for Ruby classes. In the `stories` table, I had initially named a column `type`. This column is now named `story_type`. Additionally, the data type for the column has been changed from `integer` to `string`.

The model, controller, and view partial have all been adjusted accordingly.