### PR TITLE
Adds filter to only show projects where I am an owner or member

### DIFF
--- a/frontend/components/dashboard/dashboard.jsx
+++ b/frontend/components/dashboard/dashboard.jsx
@@ -51,7 +51,9 @@ class Dashboard extends React.Component {
                   <span className="project-count">1</span>
                 </h1>
                 <ul className="project-list">
-                  {projects.map(project => <ProjectsIndexItem key={project.id} project={project} />)}
+                  {projects.map(
+                    project => (project.project_owner_id === currentUser.id || project.project_members.includes(currentUser.id)) && 
+                    (<ProjectsIndexItem key={project.id} project={project} />))}
                 </ul>
               </section>
             </section>


### PR DESCRIPTION
### Summary
Dashboard was initially showing all projects regardless of ownership or membership. A user now only sees projects where they are either the owner or a member.

### Technical Notes
This is a front end only change. When a user fetches projects on loading the dashboard, the initial page state still includes all projects.

Including these projects in state seems like it might be useful for adding a user as a member on projects where they are not yet members, but it's also possible that a future iteration would also hide these from state.