### PR TITLE
Fixes project page reload issue

### DIFF
--- a/frontend/components/navigation/top_navigation.jsx
+++ b/frontend/components/navigation/top_navigation.jsx
@@ -7,14 +7,22 @@ class TopNavigation extends React.Component {
   }
 
   render() {
-    const { currentUser, logout, projectsDropdownLabel } = this.props;
+    const { currentUser, logout, projectsDropdownLabel, project } = this.props;
 
     return (
       <>
         <header className="dashboard-header">
           <nav className="toggle-dropdown project-nav">
             <input type="checkbox" id="project-nav-toggle" />
-            { projectsDropdownLabel }
+            { projectsDropdownLabel || 
+              <label htmlFor="project-nav-toggle" className="toggle-dropdown-label">
+                <div>
+                  <img src={window.logoWhiteSmallURL} alt="Logo" className="logo-small" />
+                  <span className="project-nav-toggle-title">{project.title}</span>
+                  <span className="arrow-down"></span>
+                </div>
+              </label>
+            }
             <ul>
               <li><Link to="/dashboard"><i className="fas fa-home"></i><span>Dashboard</span></Link></li>
             </ul>

--- a/frontend/components/project/project_detail.jsx
+++ b/frontend/components/project/project_detail.jsx
@@ -13,14 +13,15 @@ class ProjectDetail extends React.Component {
   
 
   render() {
-    const { currentUser, logout, projectsDropdownLabel } = this.props;
+    debugger
+    const { currentUser, logout, project } = this.props;
 
     return (
       <>
-        <TopNavigation 
+        <TopNavigation
           currentUser={currentUser} 
           logout={logout} 
-          projectsDropdownLabel={projectsDropdownLabel}
+          project={project}
         />
         <section className="project-detail-container">
           <nav className="project-detail-sidebar">
@@ -58,9 +59,9 @@ class ProjectDetail extends React.Component {
               <header>
                 <h1>Icebox</h1>
                 <div className="project-detail-actions">
-                  <span><i class="fas fa-plus"></i> Add Story</span>
-                  <span><i class="fas fa-ellipsis-v"></i></span>
-                  <span><i class="fas fa-times"></i></span>
+                  <span><i className="fas fa-plus"></i> Add Story</span>
+                  <span><i className="fas fa-ellipsis-v"></i></span>
+                  <span><i className="fas fa-times"></i></span>
                 </div>
               </header>
               <section className="stories-stack">

--- a/frontend/components/project/project_detail_container.js
+++ b/frontend/components/project/project_detail_container.js
@@ -6,18 +6,9 @@ import { logout } from "../../actions/session_actions";
 
 const mapStateToProps = ({ session, entities: { users, projects } }, ownProps) => {
   const project = projects[ownProps.match.params.id];
-
   return {
     currentUser: users[session.id],
-    project: project,
-    projectsDropdownLabel:
-      <label htmlFor="project-nav-toggle" className="toggle-dropdown-label">
-        <div>
-          <img src={window.logoWhiteSmallURL} alt="Logo" className="logo-small" />
-          <span className="project-nav-toggle-title">{project.title}</span>
-          <span className="arrow-down"></span>
-        </div>
-      </label>
+    project: project
   }
 };
 

--- a/frontend/components/project/project_detail_container.js
+++ b/frontend/components/project/project_detail_container.js
@@ -9,7 +9,7 @@ const mapStateToProps = ({ session, entities: { users, projects } }, ownProps) =
   return {
     currentUser: users[session.id],
     project: project
-  }
+  };
 };
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION
### Summary
When a project page was reloaded it would hit an error because an object required for the state of the top navigation bar was not undefined. This issue has been resolved.

### Technical Notes
The top navigation bar component is used by both the project detail page and the dashboard. The project detail page only knows about the project object based on the pages params and only is able to access it via the component did mount lifecycle event.

As a result, the component was passing an undefined `project.title` to the top navigation bar. This issue was resolved by only passing the project as a prop rather than the HTML snippet.

The top navigation component expects a similar HTML object from the dashboard. If that object is not received, then it falls back to the code used for the project detail component.