### PR TITLE
Fixes project navigation reload issue

### DIFF
--- a/frontend/components/project/project_detail.jsx
+++ b/frontend/components/project/project_detail.jsx
@@ -13,16 +13,15 @@ class ProjectDetail extends React.Component {
   
 
   render() {
-    debugger
     const { currentUser, logout, project } = this.props;
 
     return (
       <>
-        <TopNavigation
+        {project && <TopNavigation
           currentUser={currentUser} 
           logout={logout} 
           project={project}
-        />
+        />}
         <section className="project-detail-container">
           <nav className="project-detail-sidebar">
             <ul className="project-detail-sidebar-options">


### PR DESCRIPTION
### Summary
Project page was still not able to reload because the navigation bar was not receiving the project itself as a prop. It now receives it as a prop after componentDidMount runs on the project itself.

### Technical Notes
On the initial render of a project page, the project has an undefined project as a prop. It defines the project via `componentDidMount`. The `TopNavigation` component is only rendered if the prop is defined by utilizing the short circuit evaluation pattern.