### PR TITLE
Shows user an icon for an empty story stack

### DIFF
--- a/app/assets/stylesheets/components/_story_view.scss
+++ b/app/assets/stylesheets/components/_story_view.scss
@@ -48,7 +48,7 @@
   color: $pivotalGray;
 }
 
-#story-name {
+.story-name {
   font-size: 1.25rem;
 } 
 

--- a/app/assets/stylesheets/components/_story_view.scss
+++ b/app/assets/stylesheets/components/_story_view.scss
@@ -81,6 +81,10 @@
   border-left: $lightGray solid 0.1rem;
   border-right: $lightGray solid 0.1rem;
   border-top: $lightGray solid 0.1rem;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
 }
 
 #story-state-box {
@@ -107,4 +111,8 @@
 
 .story-info-box-row .fa-cog {
   color: $choreIconGray;
+}
+
+#requester {
+  color: black;
 }

--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -1,4 +1,9 @@
 class Api::UsersController < ApplicationController
+  def index
+    @users = User.all
+    render :index
+  end
+  
   def create
     @user = User.new(params_with_username_initials)
     if @user.save

--- a/app/views/api/users/index.json.jbuilder
+++ b/app/views/api/users/index.json.jbuilder
@@ -1,0 +1,5 @@
+@users.each do |user|
+  json.set! user.id do
+    json.partial! 'user', user: user
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api, defaults: { format: :json } do
-    resources :users, only: [:create]
+    resources :users, only: [:index, :create]
     resources :projects, only: [:index, :create, :show] do
       resources :stories, only: [:index, :create, :show]
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -14,4 +14,4 @@ demo_project_1_membership_1 = ProjectMembership.create({ member_id: 1, project_i
 demo_project_1_membership_2 = ProjectMembership.create({ member_id: 2, project_id: 1 })
 demo_project_1_feature_1 = Story.create({name: "signup feature", story_type: "feature", story_owner_id: 1, project_id: 1, story_state: "unassigned"})
 demo_project_1_bug_1 = Story.create({name: "login bug", story_type: "bug", story_owner_id: 1, project_id: 1, story_state: "unassigned"})
-demo_project_1_chore_1 = Story.create({name: "backend chore", story_type: "chore", story_owner_id: 1, project_id: 1, story_state: "unassigned"})
+demo_project_1_chore_1 = Story.create({name: "backend chore for Jared", story_type: "chore", story_owner_id: 2, project_id: 1, story_state: "unassigned"})

--- a/frontend/actions/session_actions.js
+++ b/frontend/actions/session_actions.js
@@ -1,5 +1,6 @@
 import * as SessionApiUtil from '../util/session_api_util';
 
+export const RECEIVE_USERS = "RECEIVE_USERS";
 export const RECEIVE_CURRENT_USER = "RECEIVE_CURRENT_USER";
 export const LOGOUT_CURRENT_USER = "LOGOUT_CURRENT_USER";
 export const RECEIVE_SESSION_ERRORS = "RECEIVE_SESSION_ERRORS";

--- a/frontend/actions/user_actions.js
+++ b/frontend/actions/user_actions.js
@@ -1,0 +1,11 @@
+import * as UsersApiUtil from '../util/users_api_util';
+
+export const RECEIVE_USERS = "RECEIVE_USERS";
+
+const receiveUsers = (users) => ({
+  type: RECEIVE_USERS,
+  users
+});
+
+export const fetchUsers = () => dispatch => UsersApiUtil.fetchUsers()
+  .then(users => dispatch(receiveUsers(users)));

--- a/frontend/components/dashboard/dashboard.jsx
+++ b/frontend/components/dashboard/dashboard.jsx
@@ -10,6 +10,7 @@ class Dashboard extends React.Component {
 
   componentDidMount() {
     this.props.fetchProjects();
+    this.props.fetchUsers();
   }
 
   render() {

--- a/frontend/components/dashboard/dashboard_container.js
+++ b/frontend/components/dashboard/dashboard_container.js
@@ -1,7 +1,9 @@
 import React from "react";
 import { connect } from 'react-redux';
 import { logout } from '../../actions/session_actions';
-import { fetchProject, fetchProjects } from "../../actions/project_actions";
+import { fetchProjects } from "../../actions/project_actions";
+import { fetchUsers } from "../../actions/user_actions";
+import { selectAllUsers } from "../../reducers/selectors";
 import { selectAllProjects } from "../../reducers/selectors";
 import { openModal, closeModal } from '../../actions/modal_actions';
 import Dashboard from './dashboard';
@@ -10,6 +12,7 @@ import Dashboard from './dashboard';
 const mapStateToProps = ({ session, entities: { users, projects } }) => {
   return {
     currentUser: users[session.id],
+    users: selectAllUsers(users),
     projects: selectAllProjects(projects),
     projectsDropdownLabel: 
       <label htmlFor="project-nav-toggle" className="toggle-dropdown-label">
@@ -25,7 +28,8 @@ const mapDispatchToProps = dispatch => ({
   logout: () => dispatch(logout()),
   openModal: modal => dispatch(openModal(modal)),
   closeModal: () => dispatch(closeModal()),
-  fetchProjects: () => dispatch(fetchProjects())
+  fetchProjects: () => dispatch(fetchProjects()),
+  fetchUsers: () => dispatch(fetchUsers())
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Dashboard);

--- a/frontend/components/project/project_detail.jsx
+++ b/frontend/components/project/project_detail.jsx
@@ -14,8 +14,6 @@ class ProjectDetail extends React.Component {
     });
   }
 
-  
-
   render() {
     const { currentUser, logout, project, stories } = this.props;
     return (
@@ -50,17 +48,21 @@ class ProjectDetail extends React.Component {
               </header>
               <section className="stories-stack-wrapper">
                 <section className="stories-stack">
-                  <ul className="stories-list">
-                    {stories.map(
-                      story => (story.project_id === project.id && <StoryPreviewItem key={story.id} story={story} />
-                      ))}
-                  </ul>
-                  {/* <img src={window.currentBacklogEmptyURL} alt="Prioritized ideas" />
-                <div className="empty-message-text">
-                  <p>Stories you are currently working on, and stories you've prioritized
-                  to work on next live here.
-                  </p>
-                </div> */}
+                  { stories.length > 0
+                    ? <ul className="stories-list">
+                      {stories.map(
+                        story => (<StoryPreviewItem key={story.id} story={story} />
+                        ))}
+                    </ul>
+                    : <>
+                        <img src={window.currentBacklogEmptyURL} alt="Prioritized ideas" />
+                        <div className="empty-message-text">
+                          <p>Stories you are currently working on, and stories you've prioritized
+                          to work on next live here.
+                          </p>
+                        </div>
+                      </>
+                  }
                 </section>
               </section>
             </section>

--- a/frontend/components/project/project_detail.jsx
+++ b/frontend/components/project/project_detail.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import TopNavigation from "../navigation/top_navigation";
 import StoryIndexItem from "../story/stories_index_item";
-import StoryPreviewItem from "../story/story_preview_item";
+import StoryPreviewItemContainer from "../story/story_preview_item_container";
 
 class ProjectDetail extends React.Component {
   constructor(props) {
@@ -9,6 +9,7 @@ class ProjectDetail extends React.Component {
   }
 
   componentDidMount() {
+    this.props.fetchUsers();
     this.props.fetchProject(this.props.match.params.id).then(project => {
         this.props.fetchStories(project.id);
     });
@@ -51,7 +52,7 @@ class ProjectDetail extends React.Component {
                   { stories.length > 0
                     ? <ul className="stories-list">
                       {stories.map(
-                        story => (<StoryPreviewItem key={story.id} story={story} />
+                        story => (<StoryPreviewItemContainer key={`project-id_${story.project_id}_story-id_${story.id}`} story={story} />
                         ))}
                     </ul>
                     : <>

--- a/frontend/components/project/project_detail_container.js
+++ b/frontend/components/project/project_detail_container.js
@@ -2,6 +2,8 @@ import React from "react";
 import { connect } from "react-redux";
 import ProjectDetail from "./project_detail";
 import { fetchProject } from "../../actions/project_actions";
+// import { fetchUsers } from "../../actions/user_actions";
+import { selectAllUsers } from "../../reducers/selectors";
 import { fetchStories } from "../../actions/story_actions";
 import { selectAllStories } from "../../reducers/selectors";
 import { logout } from "../../actions/session_actions";
@@ -10,6 +12,7 @@ const mapStateToProps = ({ session, entities: { users, projects, stories } }, ow
   const project = projects[ownProps.match.params.id];
   return {
     currentUser: users[session.id],
+    users: users,
     project: project,
     stories: selectAllStories(stories)
   };
@@ -18,6 +21,7 @@ const mapStateToProps = ({ session, entities: { users, projects, stories } }, ow
 const mapDispatchToProps = dispatch => ({
   fetchProject: (id) => dispatch(fetchProject(id)),
   fetchStories: (projectId) => dispatch(fetchStories(projectId)),
+  fetchUsers: () => dispatch(fetchUsers()),
   logout: () => dispatch(logout())
 });
 

--- a/frontend/components/story/story_preview_item.jsx
+++ b/frontend/components/story/story_preview_item.jsx
@@ -17,6 +17,10 @@ class StoryPreviewItem extends React.Component {
     };
   }
 
+  componentDidMount() {
+    this.props.fetchUsers();
+  }
+
   render() {
     const { name, description, story_assignee_id,
       story_state, story_type
@@ -29,17 +33,17 @@ class StoryPreviewItem extends React.Component {
             <input type="text"
               placeholder="Update name of story"
               value={name}
-              id="story-name"
+              className="story-name"
             />
           </div>
           <div className="story-info-box-wrapper">
             <div className="story-info-box">
               <div className="story-info-box-row">
-                { story_type === "feature" && (<i class="fas fa-star"></i>)}
-                {story_type === "bug" && (<i class="fas fa-bug"></i>)}
-                {story_type === "chore" && (<i class="fas fa-cog"></i>)}
+                { story_type === "feature" && (<i className="fas fa-star"></i>)}
+                {story_type === "bug" && (<i className="fas fa-bug"></i>)}
+                {story_type === "chore" && (<i className="fas fa-cog"></i>)}
                 <label htmlFor="story-type">STORY TYPE</label>
-                <select name="story type" id="story-type" value={story_type}>
+                <select name="story type" value={story_type}>
                   <option value="feature">Feature</option>
                   <option value="bug">Bug</option>
                   <option value="chore">Chore</option>
@@ -47,12 +51,12 @@ class StoryPreviewItem extends React.Component {
               </div>
               <div className="story-info-box-row">
                 <label htmlFor="requester">REQUESTER</label>
-                <div id="requester">{this.props.story.story_owner_id}</div>
+                <div id="requester">{this.props.users[this.props.story.story_owner_id].name}</div>
               </div>
             </div>
             <div id="story-state-box">
               <label htmlFor="story-state">STORY STATE</label>
-              <select name="story state" id="story-state" value={story_state}>
+              <select name="story state" value={story_state}>
                 <option value="unassigned">Unassigned</option>
                 <option value="started">Started</option>
                 <option value="finished">Finished</option>
@@ -64,7 +68,6 @@ class StoryPreviewItem extends React.Component {
           <div className="story-text-field story-text-field-wrapper">
             <label htmlFor="description">DESCRIPTION</label>
             <textarea 
-              id="description" 
               cols="30" 
               rows="3"
               placeholder="Add a description"

--- a/frontend/components/story/story_preview_item_container.js
+++ b/frontend/components/story/story_preview_item_container.js
@@ -1,0 +1,21 @@
+import React from "react";
+import { connect } from "react-redux";
+import { fetchUsers } from "../../actions/user_actions";
+import { selectAllUsers } from "../../reducers/selectors";
+import StoryPreviewItem from "./story_preview_item";
+
+const mapStateToProps = ({ session, entities: { users } }) => {
+  return {
+    currentUser: users[session.id],
+    users: users
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  fetchUsers: () => dispatch(fetchUsers())
+//   fetchProject: (id) => dispatch(fetchProject(id)),
+//   fetchStories: (projectId) => dispatch(fetchStories(projectId)),
+//   logout: () => dispatch(logout())
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(StoryPreviewItem);

--- a/frontend/reducers/selectors.js
+++ b/frontend/reducers/selectors.js
@@ -1,2 +1,3 @@
+export const selectAllUsers = users => Object.values(users);
 export const selectAllProjects = projects => Object.values(projects);
 export const selectAllStories = stories => Object.values(stories);

--- a/frontend/reducers/session_reducer.js
+++ b/frontend/reducers/session_reducer.js
@@ -1,4 +1,4 @@
-import { 
+import {
   RECEIVE_CURRENT_USER, 
   LOGOUT_CURRENT_USER } from '../actions/session_actions';
 

--- a/frontend/reducers/users_reducer.js
+++ b/frontend/reducers/users_reducer.js
@@ -1,15 +1,12 @@
 import { RECEIVE_CURRENT_USER } from "../actions/session_actions";
-import { RECEIVE_PROJECT } from "../actions/project_actions";
-
+import { RECEIVE_USERS } from "../actions/user_actions";
 const usersReducer = (oldState={}, action) => {
   Object.freeze(oldState);
   switch(action.type) {
     case RECEIVE_CURRENT_USER:
       return Object.assign({}, oldState, { [action.currentUser.id]: action.currentUser });
-    case RECEIVE_PROJECT:
-      let projectOwner = [action.project.project_owner_id];
-      let projectsOwned = projectOwner.projects_owned;
-      return Object.assign({}, oldState, { projectOwner: { "projects_owned": projectsOwned }});
+    case RECEIVE_USERS:
+      return Object.assign({}, oldState, action.users);
     default:
       return oldState;
   }

--- a/frontend/stay_on_track.jsx
+++ b/frontend/stay_on_track.jsx
@@ -5,8 +5,8 @@ import Root from "./components/root";
 import * as ProjectApiUtil from "./util/projects_api_util";
 import * as SessionActions from "./actions/session_actions";
 import * as ProjectActions from "./actions/project_actions";
-import * as StoryAPIUtil from "./util/stories_api_util";
-import * as StoryActions from "./actions/story_actions";
+import * as UsersApiUtil from "./util/users_api_util";
+import * as UserActions from "./actions/user_actions";
 
 document.addEventListener("DOMContentLoaded", () => {
   let store;
@@ -34,12 +34,8 @@ document.addEventListener("DOMContentLoaded", () => {
   window.createProject = ProjectActions.createProject;
   window.ApiMembership = ProjectApiUtil.createProjectMembership;
   window.createProjectMembership = ProjectActions.createProjectMembership;
-  window.fetchProject = ProjectActions.fetchProject;
-  window.fetchProjects = ProjectActions.fetchProjects;
-  window.ApiFetchStories = StoryAPIUtil.fetchStories;
-  window.ApiFetchStory = StoryAPIUtil.fetchStory;
-  window.fetchStories = StoryActions.fetchStories;
-  window.fetchStory = StoryActions.fetchStory;
+  window.fetchUsersApi = UsersApiUtil.fetchUsers;
+  window.fetchUsers = UserActions.fetchUsers;
   // TESTING
   
   const root = document.getElementById("root");

--- a/frontend/util/users_api_util.js
+++ b/frontend/util/users_api_util.js
@@ -1,0 +1,6 @@
+export const fetchUsers = data => {
+  return $.ajax({
+    url: "/api/users",
+    data
+  });
+};


### PR DESCRIPTION
### Summary
User now sees the requester name for a story preview.

User now also sees an icon and explanation when there are no stories in the story stack. Also ensures that the story requester's id is to the right of its label.

### Technical Notes
In order to allow requester names to be visible in the preview, it was first critical to allow users to be indexed. This required changes from the backend to the frontend. These changes should allow for additional functionality related to other APIs including project membership and story assignment.