### PR TITLE
Fixes the stories reducer

### DIFF
--- a/app/assets/stylesheets/components/_story_view.scss
+++ b/app/assets/stylesheets/components/_story_view.scss
@@ -52,7 +52,7 @@
   font-size: 1.25rem;
 } 
 
-/* infobox styling for dropdowns */
+/* infobox styling for story-type, story-owner, story-state dropdowns */
 
 .story-info-box-wrapper {
   display: flex;
@@ -70,7 +70,6 @@
 .story-info-box {
   background-color: white;
   margin-left: 0.25rem;
-  border-bottom: $lightGray solid 0.1rem;
 }
 
 .story-info-box-row {
@@ -87,18 +86,22 @@
   align-items: center;
 }
 
-#story-state-box {
-  background-color: white;
-  margin-right: 0.25rem;
-  display: block;
-  height: 28px;
-  line-height: 28px;
-  padding: 0 9px;
-  border: $lightGray solid 0.1rem;
+.story-info-box-row:first-child {
+  border-top-left-radius: 0.2rem;
+  border-top-right-radius: 0.2rem;
+}
+
+.story-info-box-row:last-child {
+  border-bottom: $lightGray solid 0.1rem;
 }
 
 .story-info-box-row i {
   margin: 0 0.3rem 0 0;
+}
+
+.story-info-box-row {
+  border-bottom-left-radius: 0.1rem;
+  border-bottom-right-radius: 0.1rem;
 }
 
 .story-info-box-row .fa-star {
@@ -113,6 +116,17 @@
   color: $choreIconGray;
 }
 
-#requester {
+#story-state-box {
+  background-color: white;
+  margin-right: 0.25rem;
+  display: block;
+  height: 28px;
+  line-height: 28px;
+  padding: 0 9px;
+  border: $lightGray solid 0.1rem;
+  border-radius: 0.2rem;
+}
+
+.requester {
   color: black;
 }

--- a/frontend/components/project/project_detail.jsx
+++ b/frontend/components/project/project_detail.jsx
@@ -15,8 +15,18 @@ class ProjectDetail extends React.Component {
     });
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.match.params.id !== prevProps.match.params.id) {
+      this.props.fetchProject(this.props.match.params.id).then(project => {
+        this.props.fetchStories(project.id);
+      });
+    }
+  }
+
+
   render() {
     const { currentUser, logout, project, stories } = this.props;
+    // const projectStories = stories.filter(story => story.project_id === project.id);
     return (
       <>
         {project && <TopNavigation

--- a/frontend/components/story/story_preview_item.jsx
+++ b/frontend/components/story/story_preview_item.jsx
@@ -17,11 +17,8 @@ class StoryPreviewItem extends React.Component {
     };
   }
 
-  componentDidMount() {
-    this.props.fetchUsers();
-  }
-
   render() {
+    const { users, story } = this.props;
     const { name, description, story_assignee_id,
       story_state, story_type
     } = this.state;
@@ -51,7 +48,7 @@ class StoryPreviewItem extends React.Component {
               </div>
               <div className="story-info-box-row">
                 <label htmlFor="requester">REQUESTER</label>
-                <div id="requester">{this.props.users[this.props.story.story_owner_id].name}</div>
+                <div name="requester" className="requester">{users[story.story_owner_id].name}</div>
               </div>
             </div>
             <div id="story-state-box">

--- a/frontend/components/story/story_preview_item_container.js
+++ b/frontend/components/story/story_preview_item_container.js
@@ -11,11 +11,4 @@ const mapStateToProps = ({ session, entities: { users } }) => {
   };
 };
 
-const mapDispatchToProps = dispatch => ({
-  fetchUsers: () => dispatch(fetchUsers())
-//   fetchProject: (id) => dispatch(fetchProject(id)),
-//   fetchStories: (projectId) => dispatch(fetchStories(projectId)),
-//   logout: () => dispatch(logout())
-});
-
-export default connect(mapStateToProps, mapDispatchToProps)(StoryPreviewItem);
+export default connect(mapStateToProps)(StoryPreviewItem);

--- a/frontend/reducers/stories_reducer.js
+++ b/frontend/reducers/stories_reducer.js
@@ -5,7 +5,8 @@ const storiesReducer = (oldState = {}, action) => {
 
   switch (action.type) {
     case RECEIVE_STORIES:
-      return Object.assign({}, oldState, action.stories);
+      // return Object.assign({}, oldState, action.stories);
+      return action.stories;
     case RECEIVE_STORY:
       return Object.assign({}, oldState, { [action.story.id]: action.story });
     default:


### PR DESCRIPTION
### Summary
Every time a project is viewed, the project fetches an array of stories. It's important that the only stories loaded are the ones related to the project.

As a result, the redux state for stories must be entirely replaced on each rendering of the projects page and each time the url is updated directly.

### Technical Notes
In order to make this work in the expected way, I needed to change the `storiesReducer`, such that the object returned is always a new stories object. Initially I used `Object.assign({}, oldState, action.stories);`, but this failed because it was always additive. This is a rare case, where we shouldn't add new things to the state.

I left the old code in comments, just in case this causes problems later.