### PR TITLE
Adds ability to create stories on the UI

### DIFF
--- a/app/controllers/api/stories_controller.rb
+++ b/app/controllers/api/stories_controller.rb
@@ -26,7 +26,7 @@ class Api::StoriesController < ApplicationController
       :story_owner_id, 
       :project_id, 
       :story_state,
-      # :story_assignee_id,
+      :story_assignee_id,
       :description)
   end
 end

--- a/frontend/components/project/project_detail.jsx
+++ b/frontend/components/project/project_detail.jsx
@@ -2,10 +2,15 @@ import React from 'react';
 import TopNavigation from "../navigation/top_navigation";
 import StoryIndexItem from "../story/stories_index_item";
 import StoryPreviewItemContainer from "../story/story_preview_item_container";
+import StoryPreviewFormContainer from "../story_form/story_preview_form_container";
 
 class ProjectDetail extends React.Component {
   constructor(props) {
     super(props);
+
+    this.state=({
+      storyFormOpen: true
+    });
   }
 
   componentDidMount() {
@@ -74,6 +79,7 @@ class ProjectDetail extends React.Component {
                         </div>
                       </>
                   }
+                  {this.state.storyFormOpen && project && <StoryPreviewFormContainer project={project} />}
                 </section>
               </section>
             </section>

--- a/frontend/components/story/story_preview_item_container.js
+++ b/frontend/components/story/story_preview_item_container.js
@@ -1,7 +1,5 @@
 import React from "react";
 import { connect } from "react-redux";
-import { fetchUsers } from "../../actions/user_actions";
-import { selectAllUsers } from "../../reducers/selectors";
 import StoryPreviewItem from "./story_preview_item";
 
 const mapStateToProps = ({ session, entities: { users } }) => {

--- a/frontend/components/story_form/story_preview_form.jsx
+++ b/frontend/components/story_form/story_preview_form.jsx
@@ -1,0 +1,118 @@
+import React from 'react';
+
+class StoryPreviewForm extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      name: "",
+      description: "",
+      project_id: this.props.project.id,
+      story_owner_id: this.props.currentUser.id,
+      story_assignee_id: null,
+      story_state: "unassigned",
+      story_type: "feature"
+    };
+
+    this.update = this.update.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  update(field) {
+    return e => this.setState({
+      [field]: e.currentTarget.value
+    });
+  }
+
+  handleSubmit(e) {
+    e.preventDefault();
+    const story = Object.assign({}, this.state);
+    const projectId = story.project_id;
+
+    this.props.createStory(projectId, story).then(()=> {
+      this.setState({
+        name: "",
+        description: "",
+        project_id: this.props.project.id,
+        story_owner_id: this.props.currentUser.id,
+        story_assignee_id: null,
+        story_state: "unassigned",
+        story_type: "feature"
+      });
+    });
+  }
+
+  render() {
+    const { currentUser } = this.props;
+    const { name, description, story_assignee_id,
+      story_state, story_type
+    } = this.state;
+
+    return (
+      <>
+        <form onSubmit={this.handleSubmit} className="story-preview-edit-form">
+          <div className="story-text-field story-text-field-wrapper">
+            <input type="text"
+              placeholder="Add a name for your new story"
+              className="story-name"
+              value={name}
+              onChange={this.update("name")}
+            />
+          </div>
+          <div className="story-info-box-wrapper">
+            <div className="story-info-box">
+              <div className="story-info-box-row">
+                {story_type === "feature" && (<i className="fas fa-star"></i>)}
+                {story_type === "bug" && (<i className="fas fa-bug"></i>)}
+                {story_type === "chore" && (<i className="fas fa-cog"></i>)}
+                <label htmlFor="story-type">STORY TYPE</label>
+                <select 
+                  name="story-type" 
+                  value={story_type}
+                  onChange={this.update("story_type")}
+                  >
+                  <option value="feature">Feature</option>
+                  <option value="bug">Bug</option>
+                  <option value="chore">Chore</option>
+                </select>
+              </div>
+              <div className="story-info-box-row">
+                <label htmlFor="requester">REQUESTER</label>
+                <div name="requester" className="requester">{currentUser.name}</div>
+              </div>
+            </div>
+            <div id="story-state-box">  
+              <label htmlFor="story-state">STORY STATE</label>
+              <select name="story-state" 
+                value={story_state}
+                onChange={this.update("story_state")}
+                >
+                <option value="unassigned">Unassigned</option>
+                <option value="started">Started</option>
+                <option value="finished">Finished</option>
+                <option value="rejected">Rejected</option>
+                <option value="rejected">Accepted</option>
+              </select>
+            </div>
+          </div>
+          <div className="story-text-field story-text-field-wrapper">
+            <label htmlFor="description">DESCRIPTION</label>
+            <textarea
+              cols="30"
+              rows="3"
+              placeholder="Add a description"
+              value={description}
+              onChange={this.update("description")}              
+            ></textarea>
+          </div>
+          <input
+            type="submit"
+            className="dashboard-action-tabs-btn btn btn-green"
+            value="Submit"
+          />
+        </form>
+      </>
+    )
+  }
+}
+export default StoryPreviewForm;

--- a/frontend/components/story_form/story_preview_form_container.js
+++ b/frontend/components/story_form/story_preview_form_container.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { connect } from "react-redux";
+import { createStory } from "../../actions/story_actions";
+import StoryPreviewForm from "./story_preview_form";
+
+const mapStateToProps = ({ session, entities: { users } }) => {
+  return {
+    currentUser: users[session.id],
+    users: users
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  createStory: (projectId, story) => dispatch(createStory(projectId,story))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(StoryPreviewForm);


### PR DESCRIPTION
### Summary
A user is now able to create stories on the UI, within the projects page.

### Technical Notes
The form is difficult to see, as it appears below existing stories and does not clear after it has been submitted. 

In order to resolve these issues, I'll need to do the following:
+ Only show existing stories open if they are clicked on
+ Only show the new form if the `Add Story` button is clicked
+ Close the new form once the form is submitted (will build a handler in the project_detail container)