### PR TITLE
Adds closed view of story_preview ability to open it

### DIFF
--- a/app/assets/stylesheets/base/_colors.scss
+++ b/app/assets/stylesheets/base/_colors.scss
@@ -18,10 +18,11 @@ $primaryOrange: #ed7d1a;
 //Green
 $pivotalGreen: #56AD55;
 $pivotalGreenHover: #448A44;
-//Gold
+//Story
 $featureIconGold: #d4af37;
 $bugIconRed: #B13F44;
 $choreIconGray: #999;
+$storyBackgroundYellow: #f3f3d1;
 
 
 //Not working. Need to investigate further.

--- a/app/assets/stylesheets/components/_project_detail.scss
+++ b/app/assets/stylesheets/components/_project_detail.scss
@@ -51,7 +51,7 @@
 }
 
 .project-detail-bucket {
-  width: 50%;
+  width: 100%;
   margin: 8px;
   background-color: #484f56;
   border-radius: 2px;

--- a/app/assets/stylesheets/components/_story_view.scss
+++ b/app/assets/stylesheets/components/_story_view.scss
@@ -5,6 +5,28 @@
   width: 100%;
 }
 
+.story-preview-closed {
+  background-color: $storyBackgroundYellow;
+  color: black;
+  width: 100%;
+  // margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.story-preview-closed > div {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin: 1rem;
+}
+
+.story-preview-closed > div > div {
+  margin: 0 0.5rem 0rem 0;
+}
 
 .story-preview-edit-form {
   background-color: #e9e8e0;
@@ -105,15 +127,15 @@
   border-bottom-right-radius: 0.1rem;
 }
 
-.story-info-box-row .fa-star {
+.story-info-box-row .fa-star, .story-preview-closed .fa-star {
   color: $featureIconGold;
 }
 
-.story-info-box-row .fa-bug {
+.story-info-box-row .fa-bug, .story-preview-closed .fa-bug {
   color: $bugIconRed;
 }
 
-.story-info-box-row .fa-cog {
+.story-info-box-row .fa-cog, .story-preview-closed .fa-cog {
   color: $choreIconGray;
 }
 

--- a/frontend/components/navigation/top_navigation.jsx
+++ b/frontend/components/navigation/top_navigation.jsx
@@ -28,24 +28,24 @@ class TopNavigation extends React.Component {
             </ul>
           </nav>
           <div className="user-nav">
-            <div className="toggle-dropdown">
+            {/* <div className="toggle-dropdown">
               <input type="checkbox" id="notifications-toggle" />
               <label htmlFor="notifications-toggle" className="toggle-dropdown-label">
                 <i className="fas fa-bell"></i>
               </label>
-            </div>
-            <div className="toggle-dropdown">
+            </div> */}
+            {/* <div className="toggle-dropdown">
               <input type="checkbox" id="stayontrack-updates-toggle" />
               <label htmlFor="stayontrack-updates-toggle" className="toggle-dropdown-label">
                 <div>What's New<span className="arrow-down"></span></div>
               </label>
-            </div>
-            <div className="toggle-dropdown">
+            </div> */}
+            {/* <div className="toggle-dropdown">
               <input type="checkbox" id="help-toggle" />
               <label htmlFor="help-toggle" className="toggle-dropdown-label">
                 <div>Help<span className="arrow-down"></span></div>
               </label>
-            </div>
+            </div> */}
             <nav className="toggle-dropdown user-profile-dropdown">
               <input type="checkbox" id="user-profile-toggle" />
               <label htmlFor="user-profile-toggle" className="toggle-dropdown-label">

--- a/frontend/components/project/project_detail.jsx
+++ b/frontend/components/project/project_detail.jsx
@@ -59,14 +59,14 @@ class ProjectDetail extends React.Component {
         <section className="project-detail-container">
           <nav className="project-detail-sidebar">
             <ul className="project-detail-sidebar-options">
-              <li><i className="fas fa-inbox"></i><span>My Work</span></li>
+              {/* <li><i className="fas fa-inbox"></i><span>My Work</span></li> */}
               <li><i className="fas fa-layer-group"></i><span>Current/backlog</span></li>
-              <li><i className="far fa-snowflake"></i><span>Icebox</span></li>
+              {/* <li><i className="far fa-snowflake"></i><span>Icebox</span></li>
               <li><i className="fas fa-check"></i><span>Done</span></li>
               <li><i className="fas fa-exclamation-triangle"></i><span>Blocked</span></li>
               <li><i className="fas fa-shield-alt"></i><span>Epics</span></li>
               <li><i className="fas fa-tag"></i><span>Labels</span></li>
-              <li><i className="fas fa-history"></i><span>Project History</span></li>
+              <li><i className="fas fa-history"></i><span>Project History</span></li> */}
             </ul>
           </nav>
           <section className="project-detail-panels">
@@ -100,11 +100,10 @@ class ProjectDetail extends React.Component {
                 </section>
               </section>
             </section>
-            <section className="project-detail-bucket icebox">
+            {/* <section className="project-detail-bucket icebox">
               <header>
                 <h1>Icebox</h1>
-                <div className="project-detail-actions">
-                  <span><i className="fas fa-plus"></i> Add Story</span>
+                <div className="project-detail-actions"> <span><i className="fas fa-plus"></i> Add Story</span>
                   <span><i className="fas fa-ellipsis-v"></i></span>
                   <span><i className="fas fa-times"></i></span>
                 </div>
@@ -115,7 +114,7 @@ class ProjectDetail extends React.Component {
                   <p>Loose ideas and stories that haven't been prioritized go here.</p>
                 </div>
               </section>
-            </section>
+            </section> */}
           </section>
         </section>
       </>

--- a/frontend/components/story/story_preview_item.jsx
+++ b/frontend/components/story/story_preview_item.jsx
@@ -13,18 +13,42 @@ class StoryPreviewItem extends React.Component {
       description: description,
       story_assignee_id: story_assignee_id,
       story_state: story_state,
-      story_type: story_type
+      story_type: story_type,
+      isOpen: false
+    };
+
+    this.handleClickPreview = this.handleClickPreview.bind(this);
+  }
+
+  handleClickPreview(e) {
+    e.preventDefault();
+    this.setState({
+      isOpen: !this.state.isOpen
+    });
+  }
+
+  storyTypeIcon(story_type) {
+    switch (story_type) {
+      case "feature":
+        return <i className="fas fa-star"></i>;
+      case "bug":
+        return <i className="fas fa-bug"></i>;
+      case "chore":
+        return <i className="fas fa-cog"></i>;
+      default:
+        return;
     };
   }
 
   render() {
     const { users, story } = this.props;
     const { name, description, story_assignee_id,
-      story_state, story_type
+      story_state, story_type, isOpen
     } = this.state;
 
     return (
       <>
+        {isOpen ?
         <form className="story-preview-edit-form">
           <div className="story-text-field story-text-field-wrapper">
             <input type="text"
@@ -36,9 +60,7 @@ class StoryPreviewItem extends React.Component {
           <div className="story-info-box-wrapper">
             <div className="story-info-box">
               <div className="story-info-box-row">
-                { story_type === "feature" && (<i className="fas fa-star"></i>)}
-                {story_type === "bug" && (<i className="fas fa-bug"></i>)}
-                {story_type === "chore" && (<i className="fas fa-cog"></i>)}
+                {this.storyTypeIcon(story_type)}
                 <label htmlFor="story-type">STORY TYPE</label>
                 <select name="story type" defaultValue={story_type || ''}>
                   <option value="feature">Feature</option>
@@ -71,7 +93,15 @@ class StoryPreviewItem extends React.Component {
               defaultValue={description || ''}
             ></textarea>
           </div>
-        </form>
+          </form> :
+          <button className="story-preview-closed" onClick={this.handleClickPreview}>
+            <div>
+              <div>{this.storyTypeIcon(story_type)}</div>
+              <div>{name}</div>
+            </div>
+            <div>{story_state}</div>
+          </button>
+        }
       </>
     )
   }


### PR DESCRIPTION
### Summary
Story previews are now closed by default. While closed, the story is a button that can be clicked to open. 

The closed story preview has some useful details to view at a glance:
+ story type icon
+ story name
+ current story status
