### PR TITLE
Adds ability to update stories on the UI

### DIFF
--- a/frontend/components/story/story_preview_item.jsx
+++ b/frontend/components/story/story_preview_item.jsx
@@ -9,13 +9,13 @@ class StoryPreviewItem extends React.Component {
 
     this.state= {
       id: id,
-      project_id: project_id,
       name: name,
-      description: description,
-      story_owner_id: story_owner_id,
-      story_assignee_id: story_assignee_id,
-      story_state: story_state,
       story_type: story_type,
+      story_owner_id: story_owner_id,
+      project_id: project_id,
+      story_state: story_state,
+      story_assignee_id: story_assignee_id,
+      description: description,
       created_at: created_at,
       updated_at: updated_at,
       isOpen: false

--- a/frontend/components/story/story_preview_item.jsx
+++ b/frontend/components/story/story_preview_item.jsx
@@ -4,20 +4,62 @@ class StoryPreviewItem extends React.Component {
   constructor(props) {
     super(props);
 
-    const { name, description, story_assignee_id, 
-      story_owner_id, story_state, story_type
-    } = this.props.story;
+    const { id, name, story_type, story_owner_id, project_id, story_state, story_assignee_id, description,
+      created_at, updated_at } = this.props.story;
 
     this.state= {
+      id: id,
+      project_id: project_id,
       name: name,
       description: description,
+      story_owner_id: story_owner_id,
       story_assignee_id: story_assignee_id,
       story_state: story_state,
       story_type: story_type,
+      created_at: created_at,
+      updated_at: updated_at,
       isOpen: false
     };
 
     this.handleClickPreview = this.handleClickPreview.bind(this);
+    this.update = this.update.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  update(field) {
+    return e => this.setState({
+      [field]: e.currentTarget.value
+    });
+  }
+
+  handleSubmit(e) {
+    e.preventDefault();
+
+    const { id, name, story_type, story_owner_id, project_id, story_state, story_assignee_id, description, 
+         created_at, updated_at } = this.state;
+
+    const updatedStory = Object.assign({}, 
+      { id: id }, 
+      { name: name }, 
+      { story_type: story_type },
+      { story_owner_id: story_owner_id },
+      { project_id: project_id },
+      { story_state: story_state },
+      { story_assignee_id: story_assignee_id },
+      { description: description },
+      { created_at: created_at },
+      {updated_at: updated_at}
+    );
+  
+    if (JSON.stringify(this.props.story) !== JSON.stringify(updatedStory)) {
+      this.props.updateStory(updatedStory).then(() => {
+        this.props.fetchStories(this.props.story.project_id).then(() => {
+          this.setState({
+            isOpen: !this.state.isOpen
+          });
+        });
+      });
+    }
   }
 
   handleClickPreview(e) {
@@ -49,11 +91,12 @@ class StoryPreviewItem extends React.Component {
     return (
       <>
         {isOpen ?
-        <form className="story-preview-edit-form">
+          <form onSubmit={this.handleSubmit} className="story-preview-edit-form">
           <div className="story-text-field story-text-field-wrapper">
             <input type="text"
               placeholder="Update name of story"
               defaultValue={name || ''}
+              onChange={this.update("name")}
               className="story-name"
             />
           </div>
@@ -62,7 +105,10 @@ class StoryPreviewItem extends React.Component {
               <div className="story-info-box-row">
                 {this.storyTypeIcon(story_type)}
                 <label htmlFor="story-type">STORY TYPE</label>
-                <select name="story type" defaultValue={story_type || ''}>
+                <select name="story-type" 
+                  defaultValue={story_type || ''}
+                  onChange={this.update("story-type")}
+                >
                   <option value="feature">Feature</option>
                   <option value="bug">Bug</option>
                   <option value="chore">Chore</option>
@@ -91,6 +137,7 @@ class StoryPreviewItem extends React.Component {
               rows="3"
               placeholder="Add a description"
               defaultValue={description || ''}
+              onChange={this.update("description")}
             ></textarea>
           </div>
           <div>

--- a/frontend/components/story/story_preview_item_container.js
+++ b/frontend/components/story/story_preview_item_container.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import StoryPreviewItem from "./story_preview_item";
+import { updateStory, fetchStory, fetchStories } from "../../actions/story_actions";
 
 const mapStateToProps = ({ session, entities: { users } }) => {
   return {
@@ -9,4 +10,9 @@ const mapStateToProps = ({ session, entities: { users } }) => {
   };
 };
 
-export default connect(mapStateToProps)(StoryPreviewItem);
+const mapDispatchToProps = dispatch => ({
+  updateStory: (story) => dispatch(updateStory(story)),
+  fetchStories: (projectId) => dispatch(fetchStories(projectId))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(StoryPreviewItem);

--- a/frontend/components/story_form/story_preview_form_container.js
+++ b/frontend/components/story_form/story_preview_form_container.js
@@ -11,7 +11,7 @@ const mapStateToProps = ({ session, entities: { users } }) => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  createStory: (projectId, story) => dispatch(createStory(projectId,story))
+  createStory: (story) => dispatch(createStory(story))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(StoryPreviewForm);


### PR DESCRIPTION
### Summary
A user can update a story that they are previewing inside the project page. The preview closes as soon as the update is complete.

### Technical Notes
The frontend prevents the user from making an AJAX call if the component's story prop and its story related slices of state are identical. This was challenging to do. The component state includes `isOpen` which is a part of state, but not a part of the story prop. 

Once deconstructed, I used `Object.assign()` to create a new object that I called `updatedStory`. All of the key-value pairs for `updatedStory` needed to be in the same order as their equivalents were in the original story prop in order for me to properly compare the two. And then, I was only able to do so by "stringify"ing each of those objects using `JSON.stringify`.

There must be a more efficient and readable way. I'll investigate this further.