### PR TITLE
Stylizes cursor on hover over closed story preview

### DIFF
--- a/app/assets/stylesheets/components/_story_view.scss
+++ b/app/assets/stylesheets/components/_story_view.scss
@@ -17,6 +17,10 @@
   justify-content: space-between;
 }
 
+.story-preview-closed:hover {
+  cursor: all-scroll;
+}
+
 .story-preview-closed > div {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
### Summary
When a user hovers over the closed story preview button, they now see a cursor icon that helpfully indicates that clicking the button will expand the preview.