### PR TITLE
Adds delete story modal

### DIFF
--- a/frontend/components/modal/modal.jsx
+++ b/frontend/components/modal/modal.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { closeModal } from '../../actions/modal_actions';
 import { connect } from 'react-redux';
 import ProjectFormContainer from '../project_form/project_form_container';
+import DeleteStoryContainer from "../story/delete_story_container";
 
 function Modal({ modal, closeModal }) {
   if (!modal) {
@@ -11,6 +12,9 @@ function Modal({ modal, closeModal }) {
   switch (modal) {
     case 'create project':
       component = <ProjectFormContainer />;
+      break;
+    case 'delete story':
+      component = <DeleteStoryContainer />
       break;
     default:
       return null;

--- a/frontend/components/story/delete_story.jsx
+++ b/frontend/components/story/delete_story.jsx
@@ -1,0 +1,58 @@
+import React from "react";
+import { withRouter } from "react-router-dom";
+
+class DeleteStory extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleSubmit(e) {
+    e.preventDefault();
+    this.props.deleteStory(this.props.story);
+    this.props.closeModal();
+  }
+
+  storyTypeIcon(story_type) {
+    switch (story_type) {
+      case "feature":
+        return <i className="fas fa-star"></i>;
+      case "bug":
+        return <i className="fas fa-bug"></i>;
+      case "chore":
+        return <i className="fas fa-cog"></i>;
+      default:
+        return;
+    };
+  }
+
+  render() {
+    const { story, closeModal } = this.props;
+
+    return (
+      <>
+        <form onSubmit={this.handleSubmit} className="delete-story">
+          <h1>Delete Story</h1>
+          <div>{this.storyTypeIcon(story.story_type)} {story.name}</div>
+          <div className="modal-form-footer">
+            <input
+              type="submit"
+              className="dashboard-action-tabs-btn btn btn-green"
+              value="Delete"
+            />
+            <button
+              className="dashboard-action-tabs-btn btn btn-white"
+              onClick={closeModal}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </>
+    );
+  }
+}
+
+export default withRouter(DeleteStory);
+

--- a/frontend/components/story/delete_story_container.js
+++ b/frontend/components/story/delete_story_container.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { connect } from "react-redux";
+import { deleteStory } from "../../actions/story_actions";
+import { closeModal } from "../../actions/modal_actions";
+import DeleteStory from "./delete_story";
+
+const mapStateToProps = ({ entities: { focused_item } }) => {
+  return {
+    story: focused_item.story
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  deleteStory: (story) => dispatch(deleteStory(story)),
+  closeModal: () => dispatch(closeModal())
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(DeleteStory);

--- a/frontend/components/story/story_preview_item.jsx
+++ b/frontend/components/story/story_preview_item.jsx
@@ -24,7 +24,7 @@ class StoryPreviewItem extends React.Component {
     this.handleClickClose = this.handleClickClose.bind(this);
     this.update = this.update.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
-    this.handleDelete = this.handleDelete.bind(this);
+    this.handleDeleteModal = this.handleDeleteModal.bind(this);
   }
 
   update(field) {
@@ -71,9 +71,11 @@ class StoryPreviewItem extends React.Component {
     });
   }
 
-  handleDelete(e) {
+  handleDeleteModal(e) {
     e.preventDefault();
-    this.props.deleteStory();
+    this.props.fetchStory().then(()=> {
+      this.props.openModal('delete story');
+    });
   }
 
   storyTypeIcon(story_type) {
@@ -90,7 +92,7 @@ class StoryPreviewItem extends React.Component {
   }
 
   render() {
-    const { users, story } = this.props;
+    const { users, story, openModal } = this.props;
     const { name, description, story_assignee_id,
       story_state, story_type, isOpen
     } = this.state;
@@ -161,7 +163,7 @@ class StoryPreviewItem extends React.Component {
                 />
               </div>
               <div>
-                <button className="story-action-btn btn btn-gray" onClick={this.handleDelete}><i className="far fa-trash-alt"></i></button>
+                <button className="story-action-btn btn btn-gray" onClick={this.handleDeleteModal}><i className="far fa-trash-alt"></i></button>
               </div>
           </section>
           </form> :

--- a/frontend/components/story/story_preview_item_container.js
+++ b/frontend/components/story/story_preview_item_container.js
@@ -1,7 +1,8 @@
 import React from "react";
 import { connect } from "react-redux";
 import StoryPreviewItem from "./story_preview_item";
-import { updateStory, deleteStory } from "../../actions/story_actions";
+import { updateStory, deleteStory, fetchStory } from "../../actions/story_actions";
+import { openModal, closeModal } from '../../actions/modal_actions';
 
 const mapStateToProps = ({ session, entities: { users } }) => {
   return {
@@ -11,8 +12,10 @@ const mapStateToProps = ({ session, entities: { users } }) => {
 };
 
 const mapDispatchToProps = (dispatch, { story }) => ({
+  openModal: modal => dispatch(openModal(modal)),
   updateStory: (updatedStory) => dispatch(updateStory(updatedStory)),
-  deleteStory: () => dispatch(deleteStory(story))
+  deleteStory: () => dispatch(deleteStory(story)),
+  fetchStory: () => dispatch(fetchStory(story))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(StoryPreviewItem);

--- a/frontend/reducers/entities_reducer.js
+++ b/frontend/reducers/entities_reducer.js
@@ -2,11 +2,13 @@ import { combineReducers } from "redux";
 import usersReducer from "./users_reducer";
 import projectsReducer from "./projects_reducer";
 import storiesReducer from "./stories_reducer";
+import openStoryReducer from "./focused_item_reducer";
 
 const entitiesReducer = combineReducers({
   users: usersReducer,
   projects: projectsReducer,
-  stories: storiesReducer
+  stories: storiesReducer,
+  focused_item: openStoryReducer,
 });
 
 export default entitiesReducer;

--- a/frontend/reducers/focused_item_reducer.js
+++ b/frontend/reducers/focused_item_reducer.js
@@ -1,0 +1,20 @@
+import {
+  RECEIVE_STORY
+} from '../actions/story_actions';
+
+const _nullStory = Object.freeze({
+  id: null
+});
+
+const focusedItemReducer = (oldState = _nullStory, action) => {
+  Object.freeze(oldState);
+
+  switch (action.type) {
+    case RECEIVE_STORY:
+      return { story: action.story };
+    default:
+      return oldState;
+  }
+};
+
+export default focusedItemReducer;


### PR DESCRIPTION
### Summary
A user should be protected from accidentally deleting a story. When a user clicks the trash can icon on a story, they are redirected to a modal that provides a second prompt verifying that the user actually wants to delete the story.

### Technical Notes
I was unable to pass story object as a prop to the modal directly. I was able to resolve this problem by creating a new slice of state called `focused_item`. Whenever the delete modal is prompted, the app calls the `fetchStory` action, which returns an object `RECEIVE_STORY` to the `focused_item_reducer`.

The `focused_item_reducer` should be flexible, and possibly usable for deleting other objects like projects and/or users via a modal.