### PR TITLE
Removes ProtectedProject route code

### DIFF
--- a/frontend/components/app.jsx
+++ b/frontend/components/app.jsx
@@ -14,9 +14,8 @@ import LoginFormContainer from './session_form/login_form_container';
 import SignUpFormContainer from './session_form/signup_form_container';
 import DashboardContainer from './dashboard/dashboard_container';
 import ProjectDetailContainer from './project/project_detail_container';
-import ProjectPlaceholder from './project/project_placeholder';
 import ProjectMembershipContainer from './project_membership/project_membership_container';
-import { AuthRoute, ProtectedRoute, ProtectedProjectRoute } from '../util/route_util';
+import { AuthRoute, ProtectedRoute } from '../util/route_util';
 
 
 const App = () => (
@@ -27,8 +26,7 @@ const App = () => (
       <AuthRoute path="/login" component={LoginFormContainer} />
       <AuthRoute path="/signup" component={SignUpFormContainer} />
       <ProtectedRoute path="/dashboard" component={DashboardContainer} />
-      <ProtectedProjectRoute path="/projects/:id" component={ProjectDetailContainer} />
-      <ProtectedRoute path="/unreachable" component={ProjectPlaceholder} />
+      <ProtectedRoute path="/projects/:id" component={ProjectDetailContainer} />
       {/* <ProtectedRoute path="/projects/:id/memberships" component={ProjectMembershipContainer} /> */}
     </Switch>
     <footer>

--- a/frontend/util/route_util.jsx
+++ b/frontend/util/route_util.jsx
@@ -11,7 +11,7 @@ const Auth = ({ component: Component, path, currentUser, exact }) => (
       <Redirect to="/dashboard" />
     )
   )} />
-)
+);
 
 const Protected = ({ component: Component, path, currentUser, exact }) => (
   <Route path={path} exact={exact} render={(props) => (
@@ -21,20 +21,7 @@ const Protected = ({ component: Component, path, currentUser, exact }) => (
         <Redirect to="/login" />
       )
   )} />
-)
-
-const ProtectedProject = ({ component: Component, path, currentUser, exact }) => (
-  <Route path={path} exact={exact} render={(props) => (
-    !currentUser ? (
-      <Redirect to="/login" />
-    ) :
-    currentUser.project_memberships.includes(parseInt(props.match.params.id)) ? (
-      <Component {...props} />
-    ) : (
-        <Redirect to="/unreachable" />
-      )
-  )} />
-)
+);
 
 const mapStateToProps = ({ session, entities: { users } }) => {
   return { 


### PR DESCRIPTION
### Summary
This reverts code related to the ProtectedProject route. After testing with it, I discovered that it caused a bug preventing rerouting to a a project page on project creation.

Will investigate a different approach in a future PR.