### PR TITLE
Delete projects

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -21,7 +21,7 @@ class Api::ProjectsController < ApplicationController
   def destroy
     @project = Project.find(params[:id])
     @project.destroy
-    render json: @story
+    render json: @project
   end
 
   private

--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -18,6 +18,12 @@ class Api::ProjectsController < ApplicationController
     render :show
   end
 
+  def destroy
+    @project = Project.find(params[:id])
+    @project.destroy
+    render json: @story
+  end
+
   private
   def project_params
     params.require(:project).permit(:title, :project_owner_id)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,7 +15,7 @@ class Project < ApplicationRecord
     foreign_key: :project_owner_id,
     class_name: :User
 
-  has_many :project_memberships,
+  has_many :project_memberships, dependent: :destroy,
     foreign_key: :project_id,
     class_name: :ProjectMembership
 
@@ -23,7 +23,7 @@ class Project < ApplicationRecord
     through: :project_memberships,
     source: :member
 
-  has_many :stories,
+  has_many :stories, dependent: :destroy,
     foreign_key: :project_id,
     class_name: :Story
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   namespace :api, defaults: { format: :json } do
     resources :users, only: [:index, :create]
-    resources :projects, only: [:index, :create, :show] do
+    resources :projects, only: [:index, :create, :show, :destroy] do
       resources :stories, only: [:index, :create, :show, :update, :destroy]
     end
     resources :project_memberships, only: [:create]

--- a/frontend/actions/project_actions.js
+++ b/frontend/actions/project_actions.js
@@ -2,6 +2,7 @@ import * as ProjectApiUtil from "../util/projects_api_util";
 
 export const RECEIVE_PROJECTS = "RECEIVE_PROJECTS";
 export const RECEIVE_PROJECT = "RECEIVE_PROJECT";
+export const REMOVE_PROJECT = "REMOVE_PROJECT";
 
 const receiveProjects = (projects) => ({
   type: RECEIVE_PROJECTS,
@@ -12,6 +13,11 @@ const receiveProject = (project) => ({
   type: RECEIVE_PROJECT,
   project
 });
+
+const removeProject = (project) => ({
+  type: REMOVE_PROJECT,
+  project
+})
 
 export const fetchProjects = () => dispatch => ProjectApiUtil.fetchProjects()
   .then(projects => dispatch(receiveProjects(projects)));
@@ -33,6 +39,15 @@ export const createProject = project => dispatch => (
       return project;
     })
 );
+
+export const deleteProject = id => dispatch => {
+  return (
+    ProjectApiUtil.deleteProject(id)
+      .then(project => {
+        dispatch(removeProject(project));
+      })
+  )
+}; 
 
 export const createProjectMembership = projectMembership => dispatch => {
   return (

--- a/frontend/actions/story_actions.js
+++ b/frontend/actions/story_actions.js
@@ -45,7 +45,16 @@ export const updateStory = (story) => dispatch => (
     })
 );
 
-export const deleteStory = (story) => dispatch => (
-  StoryApiUtil.destroyStory(story)
-    .then(story => dispatch(removeStory(story)))
-);
+// export const deleteStory = (story) => dispatch => (
+//   StoryApiUtil.destroyStory(story)
+//     .then(story => dispatch(removeStory(story)))
+// );
+
+export const deleteStory = (story) => dispatch => {
+  return (
+    StoryApiUtil.destroyStory(story)
+      .then(story => {
+        dispatch(removeStory(story));
+      })
+  )
+};

--- a/frontend/components/dashboard/dashboard.jsx
+++ b/frontend/components/dashboard/dashboard.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Link } from "react-router-dom";
-import ProjectsIndexItem from "../project/projects_index_item";
+// import ProjectsIndexItem from "../project/projects_index_item";
 import TopNavigation from '../navigation/top_navigation';
+import ProjectsIndexItemContainer from '../project/projects_index_item_container';
 
 class Dashboard extends React.Component {
   constructor (props) {
@@ -57,7 +58,7 @@ class Dashboard extends React.Component {
                 <ul className="project-list">
                   {myProjects.map(
                     project => 
-                    <ProjectsIndexItem key={project.id} project={project} />
+                      <ProjectsIndexItemContainer key={project.id} project={project} />
                   )}
                 </ul>
               </section>

--- a/frontend/components/modal/modal.jsx
+++ b/frontend/components/modal/modal.jsx
@@ -3,6 +3,7 @@ import { closeModal } from '../../actions/modal_actions';
 import { connect } from 'react-redux';
 import ProjectFormContainer from '../project_form/project_form_container';
 import DeleteStoryContainer from "../story/delete_story_container";
+import DeleteProjectContainer from "../project/delete_project_container";
 import AboutDeveloper from "../navigation/about_developer";
 
 function Modal({ modal, closeModal }) {
@@ -12,10 +13,13 @@ function Modal({ modal, closeModal }) {
   let component;
   switch (modal) {
     case 'create project':
-      component = <ProjectFormContainer />;
+      component = <ProjectFormContainer />
       break;
     case 'delete story':
       component = <DeleteStoryContainer />
+      break;
+    case 'delete project':
+      component = <DeleteProjectContainer />
       break;
     case 'about the developer':
       component = <AboutDeveloper />

--- a/frontend/components/project/delete_project.jsx
+++ b/frontend/components/project/delete_project.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { withRouter } from "react-router-dom";
+
+class DeleteProject extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleSubmit = this.handleSubmit.bind(this);
+  }
+
+  handleSubmit(e) {
+    e.preventDefault();
+    this.props.deleteProject(this.props.project.id);
+    this.props.closeModal();
+  }
+
+  render() {
+    const { closeModal } = this.props;
+
+    return (
+      <>
+        <form onSubmit={this.handleSubmit} className="modal-form">
+          <h1>Delete Project</h1>
+          <div className="story-detail-wrapper">
+            <div>Are you sure that you want to delete this project? Deleting this project is permanent and will also delete any related stories.</div>
+          </div>
+          <div className="modal-form-actions">
+            <input
+              type="submit"
+              className="dashboard-action-tabs-btn btn btn-red"
+              value="Delete"
+            />
+            <button
+              className="dashboard-action-tabs-btn btn btn-white"
+              onClick={closeModal}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      </>
+    );
+  }
+}
+
+export default withRouter(DeleteProject);
+

--- a/frontend/components/project/delete_project_container.js
+++ b/frontend/components/project/delete_project_container.js
@@ -1,0 +1,18 @@
+import React from "react";
+import { connect } from "react-redux";
+import { deleteProject } from "../../actions/project_actions";
+import { closeModal } from "../../actions/modal_actions";
+import DeleteProject from "./delete_project";
+
+const mapStateToProps = ({ entities: { focused_item } }) => {
+  return {
+    project: focused_item.project
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  deleteProject: (project) => dispatch(deleteProject(project)),
+  closeModal: () => dispatch(closeModal())
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(DeleteProject);

--- a/frontend/components/project/projects_index_item.jsx
+++ b/frontend/components/project/projects_index_item.jsx
@@ -1,23 +1,42 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-const ProjectsIndexItem = ({ project }) => (
-  <li>
-    <section className="project-container">
-      <div className="project-header">
-        <Link to={`/projects/${project.id}`} className="project-title">{project.title}</Link>
-        <div className="project-header-actions">
-          {/* <a href=""><i className="far fa-heart"></i></a> */}
-          <a href=""><i className="fas fa-user-friends"></i></a>
-          {/* <a href=""><i className="fas fa-cog"></i></a> */}
-        </div>
-      </div>
-      {/* <section className="analytics">
+class ProjectsIndexItem extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleDeleteModal = this.handleDeleteModal.bind(this);
+  };
+
+  handleDeleteModal(e) {
+    e.preventDefault();
+    this.props.fetchProject().then(()=> {
+      this.props.openModal('delete project');
+    });
+  }
+
+  render() {
+    const project = this.props.project;
+
+    return (
+      <li>
+        <section className="project-container">
+          <div className="project-header">
+            <Link to={`/projects/${project.id}`} className="project-title">{project.title}</Link>
+            <div className="project-header-actions">
+              {/* <a href=""><i className="far fa-heart"></i></a> */}
+              <a href=""><i className="fas fa-user-friends"></i></a>
+              <button onClick={this.handleDeleteModal}><i className="far fa-trash-alt"></i></button>
+            </div>
+          </div>
+          {/* <section className="analytics">
         <div>Velocity 10</div>
         <div>Volatility 0%</div>
       </section> */}
-    </section>
-  </li>
-);
+        </section>
+      </li>
+    )
+  }
+}
 
 export default ProjectsIndexItem;

--- a/frontend/components/project/projects_index_item_container.js
+++ b/frontend/components/project/projects_index_item_container.js
@@ -1,0 +1,12 @@
+import React from "react";
+import { connect } from "react-redux";
+import ProjectsIndexItem from "./projects_index_item";
+import { fetchProject } from "../../actions/project_actions"; 
+import { openModal } from '../../actions/modal_actions';
+
+const mapDispatchToProps = (dispatch, { project }) => ({
+  openModal: modal => dispatch(openModal(modal)),
+  fetchProject: () => dispatch(fetchProject(project.id))
+});
+
+export default connect(null, mapDispatchToProps)(ProjectsIndexItem);

--- a/frontend/reducers/focused_item_reducer.js
+++ b/frontend/reducers/focused_item_reducer.js
@@ -2,6 +2,8 @@ import {
   RECEIVE_STORY
 } from '../actions/story_actions';
 
+import { RECEIVE_PROJECT } from '../actions/project_actions';
+
 const _nullStory = Object.freeze({
   id: null
 });
@@ -12,6 +14,8 @@ const focusedItemReducer = (oldState = _nullStory, action) => {
   switch (action.type) {
     case RECEIVE_STORY:
       return { story: action.story };
+    case RECEIVE_PROJECT:
+      return { project: action.project };
     default:
       return oldState;
   }

--- a/frontend/reducers/projects_reducer.js
+++ b/frontend/reducers/projects_reducer.js
@@ -1,4 +1,4 @@
-import { RECEIVE_PROJECT, RECEIVE_PROJECTS } from "../actions/project_actions";
+import { RECEIVE_PROJECT, RECEIVE_PROJECTS, REMOVE_PROJECT } from "../actions/project_actions";
 
 const projectsReducer = (oldState = {}, action) => {
   Object.freeze(oldState);
@@ -12,6 +12,10 @@ const projectsReducer = (oldState = {}, action) => {
       return nextState; 
     case RECEIVE_PROJECT:
       return Object.assign({}, oldState, { [action.project.id]: action.project });
+    case REMOVE_PROJECT:
+      nextState = Object.assign({}, oldState);
+      delete nextState[action.project.id];
+      return nextState;
     default:
       return oldState;
   }

--- a/frontend/stay_on_track.jsx
+++ b/frontend/stay_on_track.jsx
@@ -27,7 +27,6 @@ document.addEventListener("DOMContentLoaded", () => {
   window.dispatch = store.dispatch;
   window.ApiMembership = ProjectApiUtil.createProjectMembership;
   window.createProjectMembership = ProjectActions.createProjectMembership;
-  window.deleteProject = ProjectApiUtil.deleteProject;
   // TESTING
   
   const root = document.getElementById("root");

--- a/frontend/stay_on_track.jsx
+++ b/frontend/stay_on_track.jsx
@@ -27,6 +27,7 @@ document.addEventListener("DOMContentLoaded", () => {
   window.dispatch = store.dispatch;
   window.ApiMembership = ProjectApiUtil.createProjectMembership;
   window.createProjectMembership = ProjectActions.createProjectMembership;
+  window.deleteProject = ProjectApiUtil.deleteProject;
   // TESTING
   
   const root = document.getElementById("root");

--- a/frontend/util/projects_api_util.js
+++ b/frontend/util/projects_api_util.js
@@ -1,18 +1,10 @@
-// export const fetchProjects = data => (
-//   $.ajax({
-//     method: 'GET',
-//     url: 'api/projects',
-//     data
-//   })
-// );
-
-export const fetchProjects = data => {
-  return $.ajax({
-      method: 'GET',
-      url: 'api/projects',
-      data
-    });
-};
+export const fetchProjects = data => (
+  $.ajax({
+    method: 'GET',
+    url: 'api/projects',
+    data
+  })
+);
 
 export const fetchProject = (id) => (
   $.ajax({
@@ -26,6 +18,13 @@ export const createProject = (project) => (
     url: "/api/projects",
     method: "POST",
     data: { project }
+  })
+);
+
+export const deleteProject = (id) => (
+  $.ajax({
+    method: 'DELETE',
+    url: `api/projects/${id}`
   })
 );
 


### PR DESCRIPTION
### Summary
Adds ability for user to delete a project. When a user clicks the "delete" trashcan on a project index item in the dashboard, a modal appears that double checks if they want to delete the project. When the deletion is approved, the project, its related memberships, and its related stories are all deleted.

### Notes
Implementing this change required me to change the projects_index_item component from a functional component to a class component. Overall, the current implementation required working within several different components. In a future PR, I will consider refactoring the way that components interact with modals.

As with the story deletion modal, I am reliant on the focused_item slice of global state. This is another area ripe for a refactor.