### PR TITLE
Moves filtering of projects by current user into the backend

### DIFF
--- a/app/controllers/api/projects_controller.rb
+++ b/app/controllers/api/projects_controller.rb
@@ -1,6 +1,6 @@
 class Api::ProjectsController < ApplicationController
   def index
-    @projects = Project.all
+    @projects = current_user.projects
     render :index
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,10 @@ class User < ApplicationRecord
     foreign_key: :member_id,
     class_name: :ProjectMembership
 
+  has_many :projects,
+    through: :project_memberships,
+    source: :project
+
   has_many :stories_owned,
     foreign_key: :story_owner_id,
     class_name: :Story

--- a/frontend/components/dashboard/dashboard.jsx
+++ b/frontend/components/dashboard/dashboard.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { Link } from "react-router-dom";
-// import ProjectsIndexItem from "../project/projects_index_item";
 import TopNavigation from '../navigation/top_navigation';
 import ProjectsIndexItemContainer from '../project/projects_index_item_container';
 
@@ -11,15 +9,10 @@ class Dashboard extends React.Component {
 
   componentDidMount() {
     this.props.fetchProjects();
-    this.props.fetchUsers();
   }
 
   render() {
-    const { projects, currentUser, projectsDropdownLabel, openModal } = this.props;
-    const myProjects = projects.filter(project => (
-      project.project_owner_id === this.props.currentUser.id || 
-      project.project_members.includes(currentUser.id)
-    ));
+    const { projects, projectsDropdownLabel, openModal } = this.props;
     return (
       <>
         <TopNavigation projectsDropdownLabel={projectsDropdownLabel}/>
@@ -53,13 +46,12 @@ class Dashboard extends React.Component {
               <section className="my-projects">
                 <h1>
                   <i className="fas fa-bars"></i> <span>My Projects | </span>
-                  <span className="project-count">{myProjects.length || ""}</span>
+                  <span className="project-count">{projects.length || ""}</span>
                 </h1>
                 <ul className="project-list">
-                  {myProjects.map(
-                    project => 
-                      <ProjectsIndexItemContainer key={project.id} project={project} />
-                  )}
+                  {projects.map((project) => {
+                    <ProjectsIndexItemContainer key={project.id} project={project} /> 
+                  })};
                 </ul>
               </section>
             </section>

--- a/frontend/components/dashboard/dashboard_container.js
+++ b/frontend/components/dashboard/dashboard_container.js
@@ -1,28 +1,23 @@
-import React from "react";
+import React from 'react';
 import { connect } from 'react-redux';
-import { fetchProjects } from "../../actions/project_actions";
-import { fetchUsers } from "../../actions/user_actions";
-import { selectAllUsers } from "../../reducers/selectors";
-import { selectAllProjects } from "../../reducers/selectors";
+import { fetchProjects } from '../../actions/project_actions';
+import { selectAllProjects } from '../../reducers/selectors';
 import { openModal, closeModal } from '../../actions/modal_actions';
 import Dashboard from './dashboard';
 
-
-const mapStateToProps = ({ session, entities: { users, projects } }) => {
+const mapStateToProps = ({ entities: { projects } }) => {
   return {
-    currentUser: users[session.id],
-    users: selectAllUsers(users),
     projects: selectAllProjects(projects),
-    projectsDropdownLabel: 
+    projectsDropdownLabel: (
       <img src={window.logoWhiteURL} alt="Logo" className="logo" />
+    ),
   };
 };
 
-const mapDispatchToProps = dispatch => ({
-  openModal: modal => dispatch(openModal(modal)),
+const mapDispatchToProps = (dispatch) => ({
+  openModal: (modal) => dispatch(openModal(modal)),
   closeModal: () => dispatch(closeModal()),
   fetchProjects: () => dispatch(fetchProjects()),
-  fetchUsers: () => dispatch(fetchUsers())
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Dashboard);

--- a/frontend/components/project/project_detail_container.js
+++ b/frontend/components/project/project_detail_container.js
@@ -1,28 +1,31 @@
-import React from "react";
-import { connect } from "react-redux";
-import ProjectDetail from "./project_detail";
-import { fetchProject } from "../../actions/project_actions";
-import { fetchUsers } from "../../actions/user_actions";
-import { selectAllUsers } from "../../reducers/selectors";
-import { fetchStories } from "../../actions/story_actions";
-import { selectAllStories } from "../../reducers/selectors";
-import { logout } from "../../actions/session_actions";
+import React from 'react';
+import { connect } from 'react-redux';
+import ProjectDetail from './project_detail';
+import { fetchProject } from '../../actions/project_actions';
+import { fetchUsers } from '../../actions/user_actions';
+import { selectAllUsers } from '../../reducers/selectors';
+import { fetchStories } from '../../actions/story_actions';
+import { selectAllStories } from '../../reducers/selectors';
+import { logout } from '../../actions/session_actions';
 
-const mapStateToProps = ({ session, entities: { users, projects, stories } }, ownProps) => {
+const mapStateToProps = (
+  { session, entities: { users, projects, stories } },
+  ownProps
+) => {
   const project = projects[ownProps.match.params.id];
   return {
     currentUser: users[session.id],
     users: users,
     project: project,
-    stories: selectAllStories(stories)
+    stories: selectAllStories(stories),
   };
 };
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch) => ({
   fetchProject: (id) => dispatch(fetchProject(id)),
   fetchStories: (projectId) => dispatch(fetchStories(projectId)),
   fetchUsers: () => dispatch(fetchUsers()),
-  logout: () => dispatch(logout())
+  logout: () => dispatch(logout()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ProjectDetail);

--- a/frontend/reducers/selectors.js
+++ b/frontend/reducers/selectors.js
@@ -1,3 +1,3 @@
-export const selectAllUsers = users => Object.values(users);
-export const selectAllProjects = projects => Object.values(projects);
-export const selectAllStories = stories => Object.values(stories);
+export const selectAllUsers = (users) => Object.values(users);
+export const selectAllProjects = (projects) => Object.values(projects);
+export const selectAllStories = (stories) => Object.values(stories);


### PR DESCRIPTION
### Summary
Previously, a user who was logged in fetched all projects from the backend and then filtered them on the frontend dashboard. Now, a logged in user only gets the projects where they are a member when they fetch projects from the `./api/projects/`.

### Notes
Fix was made by referencing the `current_user` inside the `projects_controller`. Added an association in the `User` model: a `user` has many `projects` through `project_memberships`. Wrapped up with cleanup on the dashboard component in the frontend.

### Next Steps
+ Ensure that a user can only view individual projects that can be fetched via `./api/project/id`

