### PR TITLE
Defines SameSite, HTTP only, Secure, and expiration date attributes on session cookie

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,5 +59,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   # Tunnel local host to a custom domain for testing https, see example below
-  # config.hosts << "e181dd824f16.ngrok.io"
+  # config.hosts << "0ef94296301e.ngrok.io"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # Tunnel local host to a custom domain for testing https, see example below
+  # config.hosts << "e181dd824f16.ngrok.io"
 end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,1 @@
+Rails.application.config.session_store :cookie_store, same_site: :strict

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,1 +1,1 @@
-Rails.application.config.session_store :cookie_store, same_site: :strict
+Rails.application.config.session_store :cookie_store, expire_after: 14.days, key: '_session_id', httponly: :true, same_site: :strict, secure: :true


### PR DESCRIPTION
### Summary
As of February 2020, Chrome 80 started a staged rollout of "SameSite" restrictions on cookies. Other browser have since followed suit. And by default, cookies with an undefined "SameSite" attribute have been treated as "Lax". 

However, it appears that more recent changes to browsers are treating them as being set to "None", resulting in the below error for the app's session cookie: 
![samesite_error](https://user-images.githubusercontent.com/9304408/99272329-ab56df00-27f5-11eb-9ad7-c6b0f367aa3e.png)

This PR defines the "SameSite" attribute and also updates a few other security attributes: HTTP Only, Secure, and Expiration.

### Considerations
While the lowest risk of a breaking change would have been to set cookies to `same_site: :none, secure: :true`, this is also the least secure option as it allows unrestricted third party access to the session cookie so long as it is through an HTTPS connection.

Alternatively, I could have also defined the session cookie as`same_site: :lax`. In [SameSite cookies explained](https://web.dev/samesite-cookies-explained/), this seems like a great option if there were some kind of promotional add from a third party site, which add the promotion to the user's state. 

In this case, I really only use the cookie for logging the user in. So, it seems like the most secure option `same_site: :strict` is the right approach. There is no context in which I would ever need access to the session cookie outside of first-party requests.

### Notes
For more information about SameSite best practices, check out [Cookie recipes - SameSite and beyond](https://www.youtube.com/watch?v=Fet6-IiX69E).