### PR TITLE
Render projects only if available

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,5 @@
 if Rails.env === 'production' 
-  Rails.application.config.session_store :cookie_store, expire_after: 14.days, key: '_stay_on_track', domain: 'stay-on-track-app.herokuapp.com', httponly: :true, same_site: :strict, secure: :true
+  Rails.application.config.session_store :cookie_store, expire_after: 14.days, key: '_stay_on_track', path: '/', domain: 'stay-on-track-app.herokuapp.com', httponly: :true, same_site: :strict, secure: :true
 else
-  Rails.application.config.session_store :cookie_store, expire_after: 14.days, key: '_stay_on_track', httponly: :true, same_site: :strict, secure: :true
+  Rails.application.config.session_store :cookie_store, expire_after: 14.days, key: '_stay_on_track', path: '/', httponly: :true, same_site: :strict, secure: :true
 end

--- a/frontend/components/dashboard/dashboard.jsx
+++ b/frontend/components/dashboard/dashboard.jsx
@@ -8,6 +8,7 @@ class Dashboard extends React.Component {
   }
 
   componentDidMount() {
+    debugger
     this.props.fetchProjects();
   }
 
@@ -49,7 +50,7 @@ class Dashboard extends React.Component {
                   <span className="project-count">{projects.length || ""}</span>
                 </h1>
                 <ul className="project-list">
-                  {projects.map((project) => {
+                  {projects && projects.map((project) => {
                     <ProjectsIndexItemContainer key={project.id} project={project} /> 
                   })}
                 </ul>


### PR DESCRIPTION
What it says on the box. Hypothesis is that the app is rendering the React dashboard component before it has projects to render.