### PR TITLE
Fixes dashboard component and forces all access to app over SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,56 @@
 # README
+
 ![logo](./app/assets/images/marketing/StayOnTrackLogo.svg)
 
 StayOnTrack is a clone of [Pivotal Tracker](https://www.pivotaltracker.com/) -- an agile project management tool. StayOnTrack users should be able to create projects, become members of projects, write user stories, and follow user stories. Stories should be given point values that reflect complexity of work being done.
 
 ## Technologies
-+ React/Redux
-+ Ruby on Rails
-+ PostgresSQL
-+ JavaScript
+
+- React/Redux
+- Ruby on Rails
+- PostgresSQL
+- JavaScript
 
 ## Key Features
+
 ### User Authentication
-+ A user can login with existing credentials
-+ A new user may signup with a unique email address
-+ On creation, a new user account is automatically assigned with a username, name and initials
-+ Invalid credentials will trigger frontend and backend errors
+
+- A user can login with existing credentials
+- A new user may signup with a unique email address
+- On creation, a new user account is automatically assigned with a username, name and initials
+- Invalid credentials will trigger frontend and backend errors
 
 ### Dashboard
-+ The dashboard is a place for a user to see all of their projects
+
+- The dashboard is a place for a user to see all of their projects
 
 ### Projects
-+ A project is generally used to represent a broad feature set
-+ A project is owned by only one user, but can have many members
-+ A project can have many stories
+
+- A project is generally used to represent a broad feature set
+- A project is owned by only one user, but can have many members
+- A project can have many stories
 
 ## Future Improvements
-+ Stories (points, types, followers)
-+ Ability to add members to projects
-+ Automatic updating of project state as stories are completed
-+ Ability to graph project velocity over the course of a development sprint
+
+- Stories (points, types, followers)
+- Ability to add members to projects
+- Automatic updating of project state as stories are completed
+- Ability to graph project velocity over the course of a development sprint
+
+## Developer Instructions
+
+### Set up a self-signed SSL Certificate
+
+Session cookies are configured in `~/app/config/initializers/session_store.rb` to be `SameSite="Strict", Secure`. As a result, you'll need to boot the app in SSL mode.
+
+Original instructions can be viewed at [Rails Local Development over HTTPS using Self-Signed SSL Certificate](https://madeintandem.com/blog/rails-local-development-https-using-self-signed-ssl-certificate/). Note: there are many resources online covering the basics of obtaining a self-signed SSL certificate.
+
+### Start a local environment
+
+1. Start the server by running the with a binding to your self-signed SSL certificate:
+   `bundle exec rails s -b 'ssl://localhost:3000?key=path/to/file/localhost.key&cert=path/to/file/localhost.crt'`
+
+2. Start the frontend by running `npm run webpack`
+3. Open the app at `https://localhost:3000/`
 
 For additional details, view my [design docs](https://github.com/jmkaneshiro/stayontrack/wiki)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,5 +62,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   # Tunnel local host to a custom domain for testing https, see example below
-  config.hosts << "8375c8d22d7d.ngrok.io"
+  # config.hosts << "8375c8d22d7d.ngrok.io"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,9 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options)
   config.active_storage.service = :local
 
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  config.force_ssl = true
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
@@ -59,5 +62,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   # Tunnel local host to a custom domain for testing https, see example below
-  # config.hosts << "1953a26f9fa9.ngrok.io"
+  config.hosts << "8375c8d22d7d.ngrok.io"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,10 +1,3 @@
 DOMAIN = Rails.env === 'production' ? 'stay-on-track-app.herokuapp.com' : 'localhost'
 
 Rails.application.config.session_store :cookie_store, expire_after: 14.days, key: '_stayontrack_session', path: '/', domain: DOMAIN, httponly: :true, same_site: :strict, secure: :true
-
-
-# if Rails.env === 'production' 
-#   Rails.application.config.session_store :cookie_store, expire_after: EXPIRATION_INTERVAL, key: SESSION_NAME, path: '/', domain: 'stay-on-track-app.herokuapp.com', httponly: :true, same_site: :strict, secure: :true
-# else
-#   Rails.application.config.session_store :cookie_store, expire_after: EXPIRATION_INTERVAL, key: SESSION_NAME, path: '/', httponly: :true, same_site: :strict, secure: :true
-# end 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,10 @@
-if Rails.env === 'production' 
-  Rails.application.config.session_store :cookie_store, expire_after: 14.days, key: '_stayontrack_session', path: '/', domain: 'stay-on-track-app.herokuapp.com', httponly: :true, same_site: :strict, secure: :true
-else
-  Rails.application.config.session_store :cookie_store, expire_after: 14.days, key: '_stayontrack_session', path: '/', httponly: :true, same_site: :strict, secure: :true
-end
+DOMAIN = Rails.env === 'production' ? 'stay-on-track-app.herokuapp.com' : 'localhost'
+
+Rails.application.config.session_store :cookie_store, expire_after: 14.days, key: '_stayontrack_session', path: '/', domain: DOMAIN, httponly: :true, same_site: :strict, secure: :true
+
+
+# if Rails.env === 'production' 
+#   Rails.application.config.session_store :cookie_store, expire_after: EXPIRATION_INTERVAL, key: SESSION_NAME, path: '/', domain: 'stay-on-track-app.herokuapp.com', httponly: :true, same_site: :strict, secure: :true
+# else
+#   Rails.application.config.session_store :cookie_store, expire_after: EXPIRATION_INTERVAL, key: SESSION_NAME, path: '/', httponly: :true, same_site: :strict, secure: :true
+# end 

--- a/frontend/components/dashboard/dashboard.jsx
+++ b/frontend/components/dashboard/dashboard.jsx
@@ -50,7 +50,7 @@ class Dashboard extends React.Component {
                 </h1>
                 <ul className="project-list">
                   {projects.map((project) => {
-                    <ProjectsIndexItemContainer key={project.id} project={project} /> 
+                    return <ProjectsIndexItemContainer key={project.id} project={project} /> 
                   })}
                 </ul>
               </section>


### PR DESCRIPTION
### Summary
After a number of iterations, discovered that the root problem with my dashboard was not my session cookie settings, but the way that I wrote the arrow function that maps over the `projects` in the dashboard. It needed an explicit return, that I had accidentally removed.

### Notes
I was unable to see this problem in my development environment because I was not loading my development environment properly. In addition to changes for the app itself, I also included notes in the README for how to properly load up the development environment.